### PR TITLE
Fixes snatch spending 2x plasma.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
@@ -77,5 +77,4 @@
 		/datum/action/ability/xeno_action/tearingtail,
 		/datum/action/ability/xeno_action/select_reagent/panther,
 		/datum/action/ability/xeno_action/adrenaline_rush,
-		/datum/action/ability/activable/xeno/snatch,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
@@ -77,4 +77,5 @@
 		/datum/action/ability/xeno_action/tearingtail,
 		/datum/action/ability/xeno_action/select_reagent/panther,
 		/datum/action/ability/xeno_action/adrenaline_rush,
+		/datum/action/ability/activable/xeno/snatch
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -313,7 +313,6 @@
 		return FALSE
 
 /datum/action/ability/activable/xeno/snatch/use_ability(atom/A)
-	succeed_activate()
 	var/mob/living/carbon/xenomorph/X = owner
 	var/mob/living/carbon/human/victim = A
 


### PR DESCRIPTION
## `Основные изменения`
Исправил то что кража снимала плазму до того как завершилась успехом.
## `Как это улучшит игру`
В 2 раза больше тильта из-за спизженных вещей.
## `Ченджлог`
```
:cl:
fix: Кража руни теперь не снимает плазму 2 раза.
```
