### PR TITLE
Удаление штрафов псипоинтов на хайпопе

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -126,17 +126,10 @@
 
 //How many psy points a hive gets if all generators are corrupted
 #define GENERATOR_PSYCH_POINT_OUTPUT 1
-//How many psy points are gave for each marine psy drained at low pop
-#define PSY_DRAIN_REWARD_MAX 90
-//How many psy points are gave for each marine psy drained at high pop
-#define PSY_DRAIN_REWARD_MIN 30
-//How many psy points are gave every 5 second by a cocoon at low pop
-#define COCOON_PSY_POINTS_REWARD_MAX 3
-//How many psy points are gave every 5 second by a cocoon at high pop
-#define COCOON_PSY_POINTS_REWARD_MIN 1
-
-//The player pop consider to be very high pop
-#define HIGH_PLAYER_POP 80
+//How many psy points are gave for each marine psy drained
+#define PSY_DRAIN_REWARD 90
+//How many psy points are gave every 5 second by a cocoon
+#define COCOON_PSY_POINTS_REWARD 3
 
 /// How each alive marine contributes to burrower larva output per minute. So with one pool, 15 marines are giving 0.375 points per minute, so it's a new xeno every 22 minutes
 #define SILO_BASE_OUTPUT_PER_MARINE 0.035

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -127,9 +127,9 @@
 //How many psy points a hive gets if all generators are corrupted
 #define GENERATOR_PSYCH_POINT_OUTPUT 1
 //How many psy points are gave for each marine psy drained
-#define PSY_DRAIN_REWARD 90
+#define PSY_DRAIN_REWARD 60
 //How many psy points are gave every 5 second by a cocoon
-#define COCOON_PSY_POINTS_REWARD 3
+#define COCOON_PSY_POINTS_REWARD 2
 
 /// How each alive marine contributes to burrower larva output per minute. So with one pool, 15 marines are giving 0.375 points per minute, so it's a new xeno every 22 minutes
 #define SILO_BASE_OUTPUT_PER_MARINE 0.035

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -40,8 +40,7 @@
 		. += span_notice("There seems to be someone inside it. You think you can open it with a sharp object.")
 
 /obj/structure/cocoon/process()
-	var/psych_points_output = COCOON_PSY_POINTS_REWARD
-	SSpoints.add_psy_points(hivenumber, psych_points_output)
+	SSpoints.add_psy_points(hivenumber, COCOON_PSY_POINTS_REWARD)
 	//Gives marine cloneloss for a total of 30.
 	victim.adjustCloneLoss(0.5)
 

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -40,8 +40,7 @@
 		. += span_notice("There seems to be someone inside it. You think you can open it with a sharp object.")
 
 /obj/structure/cocoon/process()
-	var/psych_points_output = COCOON_PSY_POINTS_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (COCOON_PSY_POINTS_REWARD_MAX - COCOON_PSY_POINTS_REWARD_MIN))
-	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
+	var/psych_points_output = COCOON_PSY_POINTS_REWARD
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
 	//Gives marine cloneloss for a total of 30.
 	victim.adjustCloneLoss(0.5)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1225,8 +1225,7 @@
 	ADD_TRAIT(victim, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
 	if(HAS_TRAIT(victim, TRAIT_UNDEFIBBABLE))
 		victim.med_hud_set_status()
-	var/psy_points_reward = PSY_DRAIN_REWARD_MIN + ((HIGH_PLAYER_POP - SSmonitor.maximum_connected_players_count) / HIGH_PLAYER_POP * (PSY_DRAIN_REWARD_MAX - PSY_DRAIN_REWARD_MIN))
-	psy_points_reward = clamp(psy_points_reward, PSY_DRAIN_REWARD_MIN, PSY_DRAIN_REWARD_MAX)
+	var/psy_points_reward = PSY_DRAIN_REWARD
 	if(HAS_TRAIT(victim, TRAIT_HIVE_TARGET))
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_HIVE_TARGET_DRAINED, X)
 		psy_points_reward = psy_points_reward * 3


### PR DESCRIPTION
теперь за псидрейн всегда будет давать 90, а за кокон по 3 в минуту