### PR TITLE
Сварщики хотят варить в 17-ой и 18-ой броне!

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -223,6 +223,7 @@
 	flags_inv_hide = HIDEALLHAIR|HIDEEARS
 	flags_item = SYNTH_RESTRICTED
 	resistance_flags = UNACIDABLE
+	eye_protection = 2
 	anti_hug = 6
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
 
@@ -236,6 +237,7 @@
 	resistance_flags = UNACIDABLE
 	flags_item = SYNTH_RESTRICTED
 	anti_hug = 4
+	eye_protection = 2
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
 
 /obj/item/clothing/head/helmet/marine/pilot


### PR DESCRIPTION
## `Основные изменения`

Защита от сварки б-17 и б18 шлемов
## `Как это улучшит игру`
Боевые сварщики смогут варить активнее, отсутствие гемороя с менеджментом имидазолина боевым инженером, если он пользовался модулем сварки на шлеме
## `Ченджлог`
Б18-ые сварщики
```
:cl:
balance: добавление защиты от сварки б18 и 17 шлемам.
/:cl:
```
