### PR TITLE
Acid well smoke is now transparent.

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -436,7 +436,9 @@
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/burn/extinguishing
 
 /obj/effect/particle_effect/smoke/xeno/burn/extinguishing
-	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_HUGGER_PACIFY|SMOKE_EXTINGUISH
+	alpha = 120
+	opacity = FALSE
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_ACID|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
 /////////////////////////////////////////////
 // Chem smoke

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -52,7 +52,7 @@
 			to_chat(creator, span_xenoannounce("You sense your acid well at [A.name] has been destroyed!") )
 
 	if((damage_amount || damage_flag) && charges > 0) //Spawn the gas only if we actually get destroyed by damage
-		var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
+		var/datum/effect_system/smoke_spread/xeno/acid/extuingishing/A = new(get_turf(src))
 		A.set_up(clamp(CEILING(charges * 0.5, 1),0,3),src) //smoke scales with charges
 		A.start()
 	return ..()


### PR DESCRIPTION
## `Основные изменения`
Дым из кислотного колодца теперь прозрачный.

Исправлено то что при разрушении колодца, из него выходил не тот тип дыма.
## `Как это улучшит игру`
Слишком легкая дымовая завеса, с учётом того что они сами по себе заполняются.
## `Ченджлог`
```
:cl:
balance: Дым из кислотных колодцев теперь прозрачный.
fix: При уничтожении кислотного колодца из него выходит правильный дым.
/:cl:
```
