### PR TITLE
(Mostly) fixes tank minimaps (#15312) Also add idiot protection to tank fabricator.

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -532,7 +532,7 @@ SUBSYSTEM_DEF(minimaps)
 	var/atom/movable/tracking = locator_override ? locator_override : owner
 	var/atom/movable/new_track = to_track ? to_track : owner
 	if(locator_override)
-		UnregisterSignal(locator_override, COMSIG_QDELETING)
+		clear_locator_override()
 	if(owner)
 		UnregisterSignal(tracking, COMSIG_MOVABLE_Z_CHANGED)
 	if(!minimap_displayed)

--- a/code/datums/interior/_interior.dm
+++ b/code/datums/interior/_interior.dm
@@ -70,6 +70,8 @@
 /datum/interior/proc/mob_enter(mob/enterer)
 	RegisterSignal(enterer, COMSIG_QDELETING, PROC_REF(handle_occupant_del))
 	RegisterSignal(enterer, COMSIG_EXIT_AREA, PROC_REF(handle_area_leave))
+	for(var/datum/action/minimap/user_map in enterer.actions)
+		user_map.override_locator(container)
 	occupants += enterer
 	//teleporting the mob is on a case-by-case basis
 
@@ -78,6 +80,8 @@
 	UnregisterSignal(leaver, list(COMSIG_QDELETING, COMSIG_EXIT_AREA))
 	occupants -= leaver
 	exit_callback?.Invoke(leaver, src, teleport)
+	for(var/datum/action/minimap/user_map in leaver.actions)
+		user_map.clear_locator_override()
 
 ///called when a mob gets deleted while an occupant
 /datum/interior/proc/handle_occupant_del(mob/source)

--- a/code/datums/interior/interior_tank.dm
+++ b/code/datums/interior/interior_tank.dm
@@ -14,14 +14,14 @@
 	return ..()
 
 /datum/interior/armored/mob_enter(mob/enterer)
-	. = ..()
 	if(door)
 		enterer.forceMove(door.get_enter_location())
 		enterer.setDir(EAST)
-		return
+		return ..()
 	to_chat(enterer, span_userdanger("AN ERROR OCCURED PUTTING YOU INTO AN INTERIOR"))
 	stack_trace("a [enterer.type] could not find a door when entering an interior")
 	enterer.forceMove(pick(loaded_turfs))
+	return ..()
 
 /turf/closed/interior/tank
 	name = "\improper Banteng tank interior"


### PR DESCRIPTION
## `Основные изменения`
Миникарты теперь работают в миникарте.
Фабрикатор танков теперь нельзя разрушить.
## `Ченджлог`
```
:cl:
fix: Миникарты теперь работают в танках.
fix: У фабрикатора для танков теперь есть защита от дебила.
/:cl:
```
