### PR TITLE
MAPTICK_MC_MIN_RESERVE

### DIFF
--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -1,5 +1,5 @@
 /// Percentage of tick to leave for master controller to run
-#define MAPTICK_MC_MIN_RESERVE 40
+#define MAPTICK_MC_MIN_RESERVE 60
 #define MAPTICK_LAST_INTERNAL_TICK_USAGE (world.map_cpu)
 /// Amount of a tick to reserve for byond if MAPTICK_LAST_INTERNAL_TICK_USAGE is 0 or not working.
 #define TICK_BYOND_RESERVE 2


### PR DESCRIPTION
## `Основные изменения`

повысил MAPTICK_MC_MIN_RESERVE, на тг стоит 70, у нас было 40, стоит смотреть как это повлияет в самой игре в зависимости от конфигурации оборудования и как мы наговнокодили