### PR TITLE
MAPTICK_MC_MIN_RESERVE DEL

### DIFF
--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -1,16 +1,12 @@
-/// Percentage of tick to leave for master controller to run
-#define MAPTICK_MC_MIN_RESERVE 40
 #define MAPTICK_LAST_INTERNAL_TICK_USAGE (world.map_cpu)
 /// Amount of a tick to reserve for byond if MAPTICK_LAST_INTERNAL_TICK_USAGE is 0 or not working.
 #define TICK_BYOND_RESERVE 2
 /// Tick limit while running normally
-#define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
-/// Precent of a tick to require to even bother running anything. (10 percent of the tick_limit_running by default)
-#define TICK_MIN_RUNTIME (TICK_LIMIT_RUNNING * 0.1)
+#define TICK_LIMIT_RUNNING 80
 /// Tick limit used to resume things in stoplag
-#define TICK_LIMIT_TO_RUN (Master.current_ticklimit - TICK_MIN_RUNTIME)
+#define TICK_LIMIT_TO_RUN 70
 /// Tick limit for MC while running
-#define TICK_LIMIT_MC (TICK_LIMIT_RUNNING - TICK_MIN_RUNTIME)
+#define TICK_LIMIT_MC 70
 
 /// for general usage of tick_usage
 #define TICK_USAGE world.tick_usage


### PR DESCRIPTION
## `Основные изменения`

заменил тик лимиты на константные значения, кидание оба на локалке показали меньший тайм делей, но это возможно моя шиза.