### PR TITLE
Adds minimap targetting for artillery.

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -404,7 +404,7 @@ SUBSYSTEM_DEF(minimaps)
 /atom/movable/screen/minimap/proc/get_coords_from_click(mob/user)
 	//lord forgive my shitcode
 	var/signal_by_type = isobserver(user) ? COMSIG_OBSERVER_CLICKON : COMSIG_MOB_CLICKON
-	RegisterSignal(user, signal_by_type, PROC_REF(on_click))
+	RegisterSignal(user, signal_by_type, PROC_REF(on_click), TRUE)
 	while(!(choices_by_mob[user] || stop_polling) && user.client)
 		stoplag(1)
 	UnregisterSignal(user, signal_by_type)

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -75,8 +75,6 @@
 	var/static/list/id_by_type = list()
 	/// list of linked binoculars to the structure of the mortar, used for continuity to item
 	var/list/linked_struct_binoculars
-	///minimap action ref that we will display to users
-	var/datum/action/minimap/minimap
 
 /obj/machinery/deployable/mortar/Initialize(mapload, _internal_item, deployer)
 	. = ..()
@@ -92,7 +90,6 @@
 
 /obj/machinery/deployable/mortar/Destroy()
 	QDEL_NULL(impact_cam)
-	minimap = null
 	return ..()
 
 
@@ -417,6 +414,10 @@
 	return ..()
 
 /obj/machinery/deployable/mortar/on_unset_interaction(mob/user)
+	var/datum/action/minimap/minimap // not setting the var on mortar, because if there's more than 1 user it acts weird
+	for(var/datum/action/action AS in user.actions) // it needs a refactor so badly
+		if(istype(action, /datum/action/minimap))
+			minimap = action
 	minimap?.toggle_minimap(FALSE)
 
 /obj/machinery/deployable/mortar/proc/open_map(mob/user)
@@ -424,6 +425,7 @@
 		balloon_alert(user, "This region doesn't have a minimap!")
 		return
 
+	var/datum/action/minimap/minimap // not setting the var on mortar, because if there's more than 1 user it acts weird
 	for(var/datum/action/action AS in user.actions) // it needs a refactor so badly
 		if(istype(action, /datum/action/minimap))
 			minimap = action

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -432,11 +432,11 @@
 	if(!minimap)
 		balloon_alert(user, "You don't have a minimap!")
 		return
-	if(minimap.minimap_displayed) // simply close the minimap if we have it open
+	if(minimap?.minimap_displayed) // simply close the minimap if we have it open
 		minimap.toggle_minimap()
 		return
 
-	minimap.toggle_minimap(TRUE)
+	minimap?.toggle_minimap(TRUE)
 	var/list/polled_coords = minimap.map.get_coords_from_click(user)
 	minimap?.toggle_minimap(FALSE)
 

--- a/tgui/packages/tgui/interfaces/Mortar.js
+++ b/tgui/packages/tgui/interfaces/Mortar.js
@@ -102,6 +102,12 @@ export const Mortar = (props, context) => {
                   })
                 }
               />
+              <Button
+                icon="map"
+                tooltip="Minimap Targetting"
+                inline
+                onClick={() => act('open_map')}
+              />
             </Flex>
           </Flex.Item>
           <Flex.Item>


### PR DESCRIPTION
## `Основные изменения`
Добавляет кнопку для вывода координат на артиллерию с помощью миникарты. Миникарта открывается только если у тебя есть наушник с ней.
![image](https://github.com/user-attachments/assets/62189df8-6ed1-4520-8572-1e6c1849e137)

Также исправил то что при каждом юи акте, артиллерия воспроизводила сообщение о смене координат. Теперь только при их смене, как и должно быть.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Это и так можно делать если у тебя есть открытая в другой вкладке карта, так что почему бы не сделать это фичей.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
add: Добавил наводку по карте для артиллерии.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
