### PR TITLE
Proper rotate restrictions for mounted weaponry.

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -55,6 +55,7 @@
 #define COOLDOWN_TANK_SWIVEL "tank_turret_swivel"
 #define COOLDOWN_ARMORED_HORN "cooldown_armored_horn"
 #define COOLDOWN_MOB_EX_ACT "mob_ex_act"
+#define COOLDOWN_MOUNTED_GUN_ROTATE "mounted_gun_rotate"
 
 //Mecha cooldowns
 #define COOLDOWN_MECHA "mecha"

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -42,14 +42,16 @@
 ///Wrapper for proc/finish_deploy
 /datum/component/deployable_item/proc/deploy(mob/user, atom/object, turf/location, control, params)
 	SIGNAL_HANDLER
-	if(!isturf(location))
-		return
-	if(ISDIAGONALDIR(get_dir(user,location)))
+	var/list/modifiers = params2list(params)
+	if(!modifiers["ctrl"] || modifiers["right"])
 		return
 	if(parent != user.get_active_held_item())
 		return
-	var/list/modifiers = params2list(params)
-	if(!modifiers["ctrl"] || modifiers["right"] || get_turf(user) == location || !(user.Adjacent(object)) || !location)
+	if(!isturf(location))
+		return
+	if(ISDIAGONALDIR(get_dir(user, location)))
+		return
+	if(get_turf(user) == location || !(user.Adjacent(object)))
 		return
 	INVOKE_ASYNC(src, PROC_REF(finish_deploy), parent, user, location)
 	return COMSIG_KB_ACTIVATED


### PR DESCRIPTION
## `Основные изменения`
Теперь на поворот есть кд в 0.75 секунд.
Если поворот неправильный то тебе останавливает стрельбу, как и должно делать это логически.

Чутка поменял местами проверки в проке деплоя, чтобы сначала проверяло хочешь ли ты деплойнуть, и уже потом на то можешь ли ты деплойнуть.
## `Как это улучшит игру`
Больше нельзя делать вот так:

https://github.com/user-attachments/assets/dfa12958-478c-4845-8bd8-c5ea37ade73a

Так выглядит сейчас:

https://github.com/user-attachments/assets/99dfce6b-04ce-4935-8220-d2a7ef3159da

## `Ченджлог`
```
:cl:
balance: Устанавливаемые орудия теперь нельзя вращать как карусель.
fix: Теперь тебе останавливает стрельбу из установленного оружия, если ты физически не можешь из него стрелять в выбранном направлении.
/:cl:
```
