### PR TITLE
Acid smoke now damages structures and machinery.

### DIFF
--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -444,3 +444,8 @@
 	machine_stat |= DISABLED
 	density = FALSE
 	update_icon()
+
+/obj/machinery/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
+		take_damage(10 * S.strength, BURN, ACID)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -51,7 +51,7 @@
 			else
 				playsound(loc, 'sound/weapons/tap.ogg', 25, 1)
 		if(BURN)
-			playsound(loc, 'sound/items/welder.ogg', 50, 1)
+			playsound(loc, 'sound/items/welder.ogg', 25, 1)
 
 /obj/ex_act(severity, direction)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -189,3 +189,8 @@
 /obj/structure/proc/turf_cover_check(atom/movable/source)
 	SIGNAL_HANDLER
 	return TRUE
+
+/obj/structure/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
+		take_damage(10 * S.strength, BURN, ACID)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -271,6 +271,11 @@
 /obj/structure/window/GetExplosionBlock(explosion_dir)
 	return (!explosion_dir || ISDIAGONALDIR(dir) || dir & explosion_dir || REVERSE_DIR(dir) & explosion_dir) ? real_explosion_block : 0
 
+/obj/structure/window/effect_smoke(obj/effect/particle_effect/smoke/S)
+	. = ..()
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
+		take_damage(1 * S.strength, BURN, ACID) // glass doesn't care about acid
+
 /obj/structure/window/phoronbasic
 	name = "phoron window"
 	desc = "A phoron-glass alloy window. It looks insanely tough to break. It appears it's also insanely tough to burn through."

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -64,7 +64,6 @@
 		/datum/action/ability/xeno_action/create_boiler_bomb,
 		/datum/action/ability/activable/xeno/bombard,
 		/datum/action/ability/xeno_action/toggle_long_range,
-		/datum/action/ability/xeno_action/toggle_bomb,
 		/datum/action/ability/activable/xeno/spray_acid/line/boiler,
 		/datum/action/ability/xeno_action/dump_acid,
 		/datum/action/ability/xeno_action/place_trap,


### PR DESCRIPTION
## `Основные изменения`
Кислотный дым теперь дамажит структуры и машинерию.

Удалил абилку смены глобы для не примо бойлера, так как она ничего у него не делает.

Уменьшил громкость звука при получении объекта бурн урона.
## `Как это улучшит игру`
Бойлер бафф. Аое атака теперь будет дамажить окружение.
## `Ченджлог`
```
:cl:
add: Кислотный дым теперь дамажит структуры и машинерию.
/:cl:
```
