### PR TITLE
Sentry stacking restriction now works for buildasentry.

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -110,6 +110,8 @@
 #define ITEM_PREDATOR (1<<20)
 ///This item is used for autobalance calculations or excluded, such as valhalla items
 #define AUTOBALANCE_CHECK (1<<21)
+///This item is a sentry, so we won't allow to place it nearby other sentries
+#define IS_SENTRY (1<<22)
 
 //flags_storage
 ///If a storage container can be restocked into a vendor

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -95,7 +95,7 @@
 		if(LinkBlocked(get_turf(user), location))
 			location.balloon_alert(user, "No room to deploy")
 			return
-		if(istype(item_to_deploy, /obj/item/weapon/gun/sentry))
+		if(CHECK_BITFIELD(item_to_deploy.flags_item, IS_SENTRY))
 			for(var/obj/machinery/deployable/mounted/sentry/sentry in urange(2, location))
 				user.balloon_alert(user, "Слишком близко к [sentry]!")
 				return

--- a/code/datums/components/deployable_item.dm
+++ b/code/datums/components/deployable_item.dm
@@ -84,7 +84,7 @@
 			user.balloon_alert(user, "Вы уже чем-то заняты!")
 			return
 
-		if(istype(item_to_deploy, /obj/item/weapon/gun/sentry))
+		if(CHECK_BITFIELD(item_to_deploy.flags_item, IS_SENTRY))
 			for(var/obj/machinery/deployable/mounted/sentry/sentry in urange(2, location))
 				user.balloon_alert(user, "Слишком близко к [sentry]!")
 				return

--- a/code/modules/projectiles/attachables/rail.dm
+++ b/code/modules/projectiles/attachables/rail.dm
@@ -146,7 +146,7 @@
 
 /obj/item/attachable/buildasentry/on_attach(attaching_item, mob/user)
 	. = ..()
-	ENABLE_BITFIELD(master_gun.flags_item, IS_DEPLOYABLE)
+	ENABLE_BITFIELD(master_gun.flags_item, IS_DEPLOYABLE|IS_SENTRY)
 	master_gun.deployable_item = /obj/machinery/deployable/mounted/sentry/buildasentry
 	master_gun.turret_flags |= TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
 	master_gun.AddComponent(/datum/component/deployable_item, master_gun.deployable_item, deploy_time, undeploy_time)
@@ -155,7 +155,7 @@
 /obj/item/attachable/buildasentry/on_detach(detaching_item, mob/user)
 	. = ..()
 	var/obj/item/weapon/gun/detaching_gun = detaching_item
-	DISABLE_BITFIELD(detaching_gun.flags_item, IS_DEPLOYABLE)
+	DISABLE_BITFIELD(detaching_gun.flags_item, IS_DEPLOYABLE|IS_SENTRY)
 	qdel(detaching_gun.GetComponent(/datum/component/deployable_item))
 	detaching_gun.deployable_item = null
 	detaching_gun.turret_flags &= ~(TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS)

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -20,7 +20,7 @@
 	flags_gun_features = GUN_AMMO_COUNTER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_IFF|GUN_SMOKE_PARTICLES
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	deployable_item = /obj/machinery/deployable/mounted/sentry
-	flags_item = IS_DEPLOYABLE|TWOHANDED
+	flags_item = IS_DEPLOYABLE|TWOHANDED|IS_SENTRY
 	deploy_time = 5 SECONDS
 
 	allowed_ammo_types = list(/obj/item/ammo_magazine/sentry)


### PR DESCRIPTION
## `Основные изменения`
Самодельные турели теперь нельзя ставить вплотную к другим турелям.
## `Ченджлог`
```
:cl:
fix: Самодельные турели теперь нельзя ставить вплотную к другим турелям.
/:cl:
```
