### PR TITLE
Возвращение стандартного урона рапире

### DIFF
--- a/code/game/objects/items/weapons/harvester.dm
+++ b/code/game/objects/items/weapons/harvester.dm
@@ -98,7 +98,7 @@
 	)
 	icon_state = "rapier"
 	item_state = "rapier"
-	force = 60
+	force = 30
 	attack_speed = 5
 
 /obj/item/weapon/claymore/mercsword/officersword/valirapier/Initialize(mapload)


### PR DESCRIPTION
## `Основные изменения`

урон вали рапиры 60 -> 30

## `Как это улучшит игру`

Рапире бафался урон с 30 до 60 сугубо из за того, что только СЛы могли брать её, но никак не обычный морпех, в связи с недавними (или скорыми?) изменениями было бы справедливо вернуть повышенный урон обратно.

Слишком сильна против равагера