### PR TITLE
Fixes service uniform being invisible on rolling sleeves.

### DIFF
--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -256,6 +256,9 @@
 	siemens_coefficient = 0.9
 	icon_state = "marine_service" //with thanks to Fitz 'Pancake' Sholl
 	item_state = "marine_service" //with thanks to Fitz 'Pancake' Sholl
+	adjustment_variants = list(
+		"Down" = "_d",
+	)
 
 /*=========================RESPONDERS================================*/
 


### PR DESCRIPTION
## `Основные изменения`
Исправил то что у /obj/item/clothing/under/marine/service были опции для смены спрайта на несуществующие версии.
## `Ченджлог`
```
:cl:
fix: TGMC service uniform теперь не имеет функции становиться невидимым спрайтом.
/:cl:
```
