### PR TITLE
Adds 0.5 second do_after for building acid wells.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -374,11 +374,14 @@
 
 /datum/action/ability/xeno_action/place_acidwell/action_activate()
 	var/turf/T = get_turf(owner)
-	succeed_activate()
+
+	if(!do_after(owner, 0.5 SECONDS, NONE, T, BUSY_ICON_BUILD))
+		return
 
 	playsound(T, "alien_resin_build", 25)
 	new /obj/structure/xeno/acidwell(T, owner)
 
+	succeed_activate()
 	to_chat(owner, span_xenonotice("We place an acid well; it can be filled with more acid."))
 	GLOB.round_statistics.xeno_acid_wells++
 	SSblackbox.record_feedback(FEEDBACK_TALLY, "round_statistics", 1, "xeno_acid_wells")


### PR DESCRIPTION
## `Основные изменения`
Постройка колодцев с кислотой теперь занимает 0.5 секунд по времени.
## `Как это улучшит игру`
Мне не нравится то что защитная структура, может быть так легко использована в атаке.
## `Ченджлог`
```
:cl:
balance: Постройка колодцев с кислотой теперь занимает 0.5 секунды.
/:cl:
```
