### PR TITLE
Fixes most of vehicle fabricator bullshit.

### DIFF
--- a/code/modules/reqs/_supply.dm
+++ b/code/modules/reqs/_supply.dm
@@ -919,6 +919,12 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 				to_chat(usr, span_danger("A vehicle of this type has already been purchased!"))
 				return
 			current_veh_type = newtype
+			current_primary = null // set everything to null, to avoid bugs
+			current_secondary = null
+			current_driver_mod = null
+			current_gunner_mod = null
+			primary_ammo = list()
+			secondary_ammo = list()
 			. = TRUE
 
 		if("setprimary")
@@ -1016,6 +1022,7 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			current_gunner_mod = null
 			primary_ammo = list()
 			secondary_ammo = list()
+			update_static_data(usr)
 
 	if(.)
 		update_static_data(usr)

--- a/code/modules/reqs/_supply.dm
+++ b/code/modules/reqs/_supply.dm
@@ -1009,6 +1009,13 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			supply_shuttle.buy(usr, src)
 			ui_act("send", params, ui, state)
 			SStgui.close_user_uis(usr, src)
+			current_veh_type = null
+			current_primary = null
+			current_secondary = null
+			current_driver_mod = null
+			current_gunner_mod = null
+			primary_ammo = list()
+			secondary_ammo = list()
 
 	if(.)
 		update_static_data(usr)


### PR DESCRIPTION
## `Основные изменения`
При покупке или переключении на другой транспорт, все орудия, модули и патроны сбрасываются, что предотвращает целую кучу возможного сломанного говна.
## `Как это улучшит игру`
Нету танков с бесконечными патронами на основной ствол.
## `Ченджлог`
```
:cl:
fix: При покупке или переключении выбора транспорта в фабрикаторе транспорта, теперь сбрасывается выбор орудий, модулей и патрон, что исправляет танки с интерьером АПЦ и бесконечными патронами.
/:cl:
```
