### PR TITLE
`structure/xeno/Destroy()` now doesn't try to look for structure in critical structures if structure isn't critical.

### DIFF
--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -18,7 +18,10 @@
 		LAZYADDASSOC(GLOB.xeno_critical_structures_by_hive, hivenumber, src)
 
 /obj/structure/xeno/Destroy()
-	if(!locate(src) in GLOB.xeno_structures_by_hive[hivenumber]+GLOB.xeno_critical_structures_by_hive[hivenumber]) //The rest of the proc is pointless to look through if its not in the lists
+	var/list/list_to_check = GLOB.xeno_structures_by_hive[hivenumber]
+	if(xeno_structure_flags & CRITICAL_STRUCTURE)
+		list_to_check += GLOB.xeno_critical_structures_by_hive[hivenumber]
+	if(!locate(src) in list_to_check) //The rest of the proc is pointless to look through if its not in the lists
 		stack_trace("[src] not found in the list of (potentially critical) xeno structures!") //We dont want to CRASH because that'd block deletion completely. Just trace it and continue.
 		return ..()
 	GLOB.xeno_structures_by_hive[hivenumber] -= src

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -18,11 +18,10 @@
 		LAZYADDASSOC(GLOB.xeno_critical_structures_by_hive, hivenumber, src)
 
 /obj/structure/xeno/Destroy()
-	var/list/list_to_check = GLOB.xeno_structures_by_hive[hivenumber]
-	if(xeno_structure_flags & CRITICAL_STRUCTURE)
-		list_to_check += GLOB.xeno_critical_structures_by_hive[hivenumber]
-	if(!locate(src) in list_to_check) //The rest of the proc is pointless to look through if its not in the lists
-		stack_trace("[src] not found in the list of (potentially critical) xeno structures!") //We dont want to CRASH because that'd block deletion completely. Just trace it and continue.
+	//The rest of the proc is pointless to look through if its not in the lists
+	if(!locate(src) in GLOB.xeno_structures_by_hive[hivenumber] || xeno_structure_flags & CRITICAL_STRUCTURE && !locate(src) in GLOB.xeno_critical_structures_by_hive[hivenumber])
+		//We dont want to CRASH because that'd block deletion completely. Just trace it and continue.
+		stack_trace("[src] not found in the list of (potentially critical) xeno structures!")
 		return ..()
 	GLOB.xeno_structures_by_hive[hivenumber] -= src
 	if(xeno_structure_flags & CRITICAL_STRUCTURE)

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -18,14 +18,16 @@
 		LAZYADDASSOC(GLOB.xeno_critical_structures_by_hive, hivenumber, src)
 
 /obj/structure/xeno/Destroy()
-	//The rest of the proc is pointless to look through if its not in the lists
-	if(!locate(src) in GLOB.xeno_structures_by_hive[hivenumber] || xeno_structure_flags & CRITICAL_STRUCTURE && !locate(src) in GLOB.xeno_critical_structures_by_hive[hivenumber])
+	if(!locate(src) in GLOB.xeno_structures_by_hive[hivenumber])
 		//We dont want to CRASH because that'd block deletion completely. Just trace it and continue.
-		stack_trace("[src] not found in the list of (potentially critical) xeno structures!")
-		return ..()
-	GLOB.xeno_structures_by_hive[hivenumber] -= src
+		stack_trace("[src] not found in the list of xeno structures!")
+	else
+		GLOB.xeno_structures_by_hive[hivenumber] -= src
 	if(xeno_structure_flags & CRITICAL_STRUCTURE)
-		GLOB.xeno_critical_structures_by_hive[hivenumber] -= src
+		if(!locate(src) in GLOB.xeno_critical_structures_by_hive[hivenumber])
+			stack_trace("[src] not found in the list of critical xeno structures!")
+		else
+			GLOB.xeno_critical_structures_by_hive[hivenumber] -= src
 	return ..()
 
 /obj/structure/xeno/ex_act(severity)


### PR DESCRIPTION
## `Основные изменения`
Фиксит вот это.
![image](https://github.com/user-attachments/assets/ba2f60d3-2606-4dde-8d97-25184bc4266d)
## `Ченджлог`
На игре никак не отобразится.
