### PR TITLE
Adds cargo droid for Talos.

### DIFF
--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -23826,10 +23826,10 @@
 /turf/open/floor/plating/plating_catwalk/light,
 /area/mainship/squads/delta)
 "nZw" = (
-/obj/vehicle/ridden/powerloader,
 /obj/machinery/light/mainship/small{
 	dir = 8
 	},
+/obj/vehicle/unmanned/droid/ripley,
 /turf/open/floor/prison/plate,
 /area/mainship/squads/req)
 "nZT" = (


### PR DESCRIPTION
## `Основные изменения`
Заменил рипли в карго на рипли дроид для ИИ.
## `Как это улучшит игру`
ИИ теперь может быть грузчиком на пол ставки.
## `Ченджлог`
```
:cl:
map: На Талос добавлен карго дроид для ИИ.
/:cl:
```
