### PR TITLE
Fixes pilotbunks door access so it can be opened by a pilot.

### DIFF
--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -20610,7 +20610,7 @@
 /area/mainship/command/cic)
 "moF" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_one_access = list(2,7,44)
+	req_one_access = list(44)
 	},
 /turf/open/floor/plating,
 /area/mainship/living/pilotbunks)

--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -20609,7 +20609,9 @@
 /turf/open/floor/mainship/metal,
 /area/mainship/command/cic)
 "moF" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint{
+	req_one_access = list(2,7,44)
+	},
 /turf/open/floor/plating,
 /area/mainship/living/pilotbunks)
 "moG" = (


### PR DESCRIPTION
## `Основные изменения`
Исправил доступ на двери в комнатах пилотов, чтобы её мог открыть пилот.
## `Ченджлог`
```
:cl:
map: [Талос] Исправлена дверь в комнате пилота, не открывающаяся доступом пилота.
/:cl:
```
