### PR TITLE
Makes xeno manifest actually useful. Unifies Marine Manifest and Xeno manifest in 1 lobby button.

### DIFF
--- a/code/_onclick/hud/screen_objects/menu_text_objects.dm
+++ b/code/_onclick/hud/screen_objects/menu_text_objects.dm
@@ -104,22 +104,17 @@
 	update_text()
 
 /atom/movable/screen/text/lobby/clickable/manifest
-	maptext = "<span class='maptext' style=font-size:8px>МАНИФЕСТ МОРПЕХОВ</span>"
+	maptext = "<span class='maptext' style=font-size:8px>МАНИФЕСТ</span>"
 	icon_state = "manifest"
 
 /atom/movable/screen/text/lobby/clickable/manifest/Click()
 	. = ..()
 	var/mob/new_player/player = hud.mymob
-	player.view_manifest()
-
-/atom/movable/screen/text/lobby/clickable/xenomanifest
-	maptext = "<span class='maptext' style=font-size:8px>МАНИФЕСТ УЛЬЯ</span>"
-	icon_state = "manifest"
-
-/atom/movable/screen/text/lobby/clickable/xenomanifest/Click()
-	. = ..()
-	var/mob/new_player/player = hud.mymob
-	player.view_xeno_manifest()
+	switch(tgui_alert(player, "Whose Manifest do you want to see?", "Choose Manifest", list("Marine", "Xenomorph")))
+		if("Marine")
+			player.view_manifest()
+		if("Xenomorph")
+			player.view_xeno_manifest()
 
 /atom/movable/screen/text/lobby/clickable/background
 	maptext = "<span class='maptext' style=font-size:8px>ПРЕДЫСТОРИЯ</span>"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -143,9 +143,37 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 
 	if(length(HN.xeno_leader_list) > 0)
 		dat += "<tr><th colspan=3>Hive Leaders</th></tr>"
-		for(var/x in HN.xeno_leader_list)
-			var/mob/living/carbon/xenomorph/leader = x
+		for(var/xeno AS in HN.xeno_leader_list)
+			var/mob/living/carbon/xenomorph/leader = xeno
 			dat += "<tr[even ? " class='alt'" : ""]><td>[leader.xeno_caste.display_name]</td><td>[leader.name]</td></tr>"
+			even = !even
+
+	if(length(HN.xenos_by_tier[XENO_TIER_THREE]))
+		dat += "<tr><th colspan=3>T3 Xenomorphs</th></tr>"
+		for(var/xeno AS in HN.xenos_by_tier[XENO_TIER_THREE])
+			var/mob/living/carbon/xenomorph/t3_xeno = xeno
+			dat += "<tr[even ? " class='alt'" : ""]><td>[t3_xeno.xeno_caste.display_name]</td><td>[t3_xeno.name]</td></tr>"
+			even = !even
+
+	if(length(HN.xenos_by_tier[XENO_TIER_TWO]))
+		dat += "<tr><th colspan=3>T2 Xenomorphs</th></tr>"
+		for(var/xeno AS in HN.xenos_by_tier[XENO_TIER_TWO])
+			var/mob/living/carbon/xenomorph/t2_xeno = xeno
+			dat += "<tr[even ? " class='alt'" : ""]><td>[t2_xeno.xeno_caste.display_name]</td><td>[t2_xeno.name]</td></tr>"
+			even = !even
+
+	if(length(HN.xenos_by_tier[XENO_TIER_ONE]))
+		dat += "<tr><th colspan=3>T1 Xenomorphs</th></tr>"
+		for(var/xeno AS in HN.xenos_by_tier[XENO_TIER_ONE])
+			var/mob/living/carbon/xenomorph/t1_xeno = xeno
+			dat += "<tr[even ? " class='alt'" : ""]><td>[t1_xeno.xeno_caste.display_name]</td><td>[t1_xeno.name]</td></tr>"
+			even = !even
+
+	if(length(HN.xenos_by_tier[XENO_TIER_ZERO]))
+		dat += "<tr><th colspan=3>T0 Xenomorphs</th></tr>"
+		for(var/xeno AS in HN.xenos_by_tier[XENO_TIER_ZERO])
+			var/mob/living/carbon/xenomorph/t0_xeno = xeno
+			dat += "<tr[even ? " class='alt'" : ""]><td>[t0_xeno.xeno_caste.display_name]</td><td>[t0_xeno.name]</td></tr>"
 			even = !even
 
 	dat += "</table>"


### PR DESCRIPTION
## `Основные изменения`
![image](https://github.com/user-attachments/assets/2987036d-e28e-488d-874b-8708dbfb974a)
## `Как это улучшит игру`
Можно решить хочешь ли ты играть за ксеносов прямо из лобби.
## `Ченджлог`
```
:cl:
qol: Ксено манифест теперь отображает всех ксеносов в хайве.
/:cl:
```
