### PR TITLE
nerf acidblood 15-30 >> 5-15

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -189,4 +189,4 @@
 				span_danger("You are splattered with sizzling blood! IT BURNS!"))
 				if(victim.stat == CONSCIOUS && !(victim.species.species_flags & NO_PAIN))
 					victim.emote("scream")
-				victim.take_overall_damage(rand(15, 30), BURN, ACID, updating_health = TRUE)
+				victim.take_overall_damage(rand(5, 15), BURN, ACID, updating_health = TRUE)


### PR DESCRIPTION
## `Основные изменения`
Рандом урона 15-30 от ацидблада понижен до 5-15

## `Как это улучшит игру`
Механика ацидблада не убивает в 100% случаях зажима в мили зоне. Однако, все еще остается наносящей урон.

## `Ченджлог`
```
:cl:
balance: ацидблад наносит 5-15 урона кислотой заместо 15-30
/:cl:
```
