### PR TITLE
Deletes tx54 he ammo.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -217,7 +217,6 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 	/obj/item/ammo_magazine/shotgun/mbx900/buckshot = list(CAT_LEDSUP, "A box of .410 buckshot rounds", 1, "orange2"),
 	/obj/item/weapon/gun/rifle/tx55 = list(CAT_LEDSUP, "AR-55 OICW Rifle", 15, "red"),
 	/obj/item/ammo_magazine/rifle/tx54 = list(CAT_LEDSUP, "GL-54 Flak Magazine for AR-55/GL-54", 2, "orange2"),
-	/obj/item/ammo_magazine/rifle/tx54/he = list(CAT_LEDSUP, "GL-54 HE Magazine for AR-55/GL-54", 3, "orange2"),
 	/obj/item/ammo_magazine/rifle/tx54/smoke = list(CAT_LEDSUP, "GL-54 tactical smoke Magazine for AR-55/GL-54", 1, "orange2"),
 	/obj/item/ammo_magazine/rifle/tx54/smoke/tangle = list(CAT_LEDSUP, "GL-54 Tanglefoot Magazine for AR-55/GL-54", 3, "orange2"),
 	/obj/item/cell/lasgun/lasrifle/recharger = list(CAT_LEDSUP, "Terra Experimental recharger battery", 4, "orange2"),

--- a/code/game/objects/items/loot_box.dm
+++ b/code/game/objects/items/loot_box.dm
@@ -512,12 +512,12 @@
 	new /obj/item/ammo_magazine/rifle/tx54(src)
 	new /obj/item/ammo_magazine/rifle/tx54(src)
 	new /obj/item/ammo_magazine/rifle/tx54(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
-	new /obj/item/ammo_magazine/rifle/tx54/he(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
+	new /obj/item/ammo_magazine/rifle/tx54/incendiary(src)
 
 // Uncommon
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -523,7 +523,6 @@
 			/obj/item/weapon/gun/rifle/tx54 = -1,
 			/obj/item/ammo_magazine/rifle/tx54 = -1,
 			/obj/item/ammo_magazine/rifle/tx54/incendiary = -1,
-			/obj/item/ammo_magazine/rifle/tx54/he = -1,
 			/obj/item/ammo_magazine/rifle/tx54/smoke = -1,
 			/obj/item/ammo_magazine/rifle/tx54/smoke/dense = -1,
 			/obj/item/ammo_magazine/rifle/tx54/smoke/tangle = -1,

--- a/code/modules/codex/entries/magazine_codex.dm
+++ b/code/modules/codex/entries/magazine_codex.dm
@@ -102,9 +102,6 @@
 /obj/item/ammo_magazine/rifle/tx54/get_additional_codex_info()
 	. += "20mm airburst grenades release a number of piercing sub munitions when they detonate. Submunitions inflict damage, sunder, stagger and slow.<br>"
 
-/obj/item/ammo_magazine/rifle/tx54/he/get_additional_codex_info()
-	. += "20mm high explosive grenades instantly detonate on impact on the turf targeted, creating a small explosion.<br>"
-
 /obj/item/ammo_magazine/rifle/tx54/incendiary/get_additional_codex_info()
 	. += "20mm incendiary grenades release a number of piercing sub munitions when they detonate. Submunitions burn any mob they hit, and leave fire in turfs crossed.<br>"
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1901,7 +1901,6 @@
 	default_ammo_type = null
 	allowed_ammo_types = list(
 		/obj/item/ammo_magazine/rifle/tx54,
-		/obj/item/ammo_magazine/rifle/tx54/he,
 		/obj/item/ammo_magazine/rifle/tx54/incendiary,
 		/obj/item/ammo_magazine/rifle/tx54/smoke,
 		/obj/item/ammo_magazine/rifle/tx54/smoke/dense,

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -481,14 +481,6 @@
 	greyscale_config = /datum/greyscale_config/ammo
 	greyscale_colors = COLOR_AMMO_AIRBURST
 
-/obj/item/ammo_magazine/rifle/tx54/he
-	name = "\improper 20mm HE grenade magazine"
-	desc = "A 20mm magazine loaded with HE grenades. For use with the GL-54 or AR-55."
-	default_ammo = /datum/ammo/tx54/he
-	icon_state = "tx54_airburst"
-	icon_state_mini = "mag_sniper_red"
-	greyscale_colors = COLOR_AMMO_HIGH_EXPLOSIVE
-
 /obj/item/ammo_magazine/rifle/tx54/incendiary
 	name = "\improper 20mm incendiary grenade magazine"
 	desc = "A 20mm magazine loaded with incendiary grenades. For use with the GL-54 or AR-55."

--- a/code/modules/reqs/weapons.dm
+++ b/code/modules/reqs/weapons.dm
@@ -236,11 +236,6 @@
 	contains = list(/obj/item/ammo_magazine/rifle/tx54/smoke/tangle)
 	cost = 48
 
-/datum/supply_packs/weapons/tx54_he
-	name = "GL-54 HE grenade magazine"
-	contains = list(/obj/item/ammo_magazine/rifle/tx54/he)
-	cost = 50
-
 /datum/supply_packs/weapons/tx55
 	name = "AR-55 OICW Rifle"
 	contains = list(/obj/item/weapon/gun/rifle/tx55)


### PR DESCRIPTION
## `Основные изменения`
Удалил ХЕ патроны на tx54.
## `Как это улучшит игру`
Данный тип снарядов не удался концептуально. На данный момент эти патроны стоят дороже чем обычные, но уступают им чуть ли не во всём, но если им повысить силу взрыва, то это будут уже ИФФ ракеты из-за экрана. В обоих случаях будет говном, просто для разных сторон.
## `Ченджлог`
```
:cl:
del: Удалил ХЕ патроны на tx54.
/:cl:
```
