### PR TITLE
Adds delay for powerpacks and packet filling.

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -156,10 +156,10 @@
 		to_chat(user, span_warning("\The [source] is empty."))
 		return
 
-	//using handfuls; and filling internal mags has no delay.
-	if(fill_delay)
+	//if the source has a fill_delay, delay the reload by this amount.
+	if(source.fill_delay)
 		to_chat(user, span_notice("You start refilling [src] with [source]."))
-		if(!do_after(user, fill_delay, NONE, src, BUSY_ICON_GENERIC))
+		if(!do_after(user, source.fill_delay, NONE, src, BUSY_ICON_GENERIC))
 			return
 
 	to_chat(user, span_notice("You refill [src] with [source]."))

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -118,6 +118,7 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	flags_magazine_features = MAGAZINE_REFUND_IN_CHAMBER|MAGAZINE_WORN
 	w_class = WEIGHT_CLASS_HUGE
+	reload_delay = 0.5 SECONDS
 	slowdown = 0.2
 	maxcharge = 3000
 	self_recharge = TRUE

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -5,7 +5,7 @@
 	desc = "A packet containing some kind of ammo."
 	icon_state_mini = "ammo_packet"
 	w_class = WEIGHT_CLASS_NORMAL
-	fill_delay = 1 SECONDS
+	fill_delay = 0.75 SECONDS
 
 /obj/item/ammo_magazine/packet/attack_hand_alternate(mob/living/user)
 	. = ..()

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -5,6 +5,7 @@
 	desc = "A packet containing some kind of ammo."
 	icon_state_mini = "ammo_packet"
 	w_class = WEIGHT_CLASS_NORMAL
+	fill_delay = 1 SECONDS
 
 /obj/item/ammo_magazine/packet/attack_hand_alternate(mob/living/user)
 	. = ..()

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -408,6 +408,7 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	flags_magazine = MAGAZINE_WORN
 	w_class = WEIGHT_CLASS_HUGE
+	reload_delay = 0.5 SECONDS
 	default_ammo = /datum/ammo/bullet/minigun
 	current_rounds = 600
 	max_rounds = 600
@@ -436,7 +437,6 @@
 	caliber = CALIBER_10x26_CASELESS
 	flags_item_map_variant = null
 
-
 // ICC coilgun
 
 /obj/item/ammo_magazine/rifle/icc_coilgun
@@ -448,4 +448,3 @@
 	max_rounds = 5
 	reload_delay = 10
 	icon_state_mini = "mag_dmr"
-


### PR DESCRIPTION
## `Основные изменения`
У паверпаков для минигана и лазерок теперь есть задержка в 0.5 секунд перед подключением.
У коробок с патронами теперь есть задержка в 0.75 секунд перед заполнением магазина.
## `Как это улучшит игру`
У паверпаков и коробок с патронами должен быть минимальный минус в виде громоздкости, иначе резон использовать обычные магазины пропадает.
## `Ченджлог`
```
:cl:
balance: Паверпаки теперь имеют задержку в 0.5 секунд перед подключением.
balance: Коробки с патронами теперь имеют задержку перед пополнением в 0.75 секунд.
/:cl:
```
