### PR TITLE
Crusher bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -224,7 +224,6 @@
 		charge.charge_dir = aimdir //Set dir so check_momentum() does not cuck us
 	for(var/i=0 to max(get_dist(X, A), advance_range))
 		if(i % 2)
-			playsound(X, "alien_charge", 50)
 			new /obj/effect/temp_visual/xenomorph/afterimage(get_turf(X), X)
 		X.Move(get_step(X, aimdir), aimdir)
 		aimdir = get_dir(X, A)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -58,8 +58,8 @@
 /datum/action/ability/xeno_action/ready_charge/proc/charge_on(verbose = TRUE)
 	var/mob/living/carbon/xenomorph/charger = owner
 	charge_ability_on = TRUE
-	RegisterSignal(charger, COMSIG_MOVABLE_MOVED, PROC_REF(update_charging))
-	RegisterSignal(charger, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_change))
+	RegisterSignal(charger, COMSIG_MOVABLE_MOVED, PROC_REF(update_charging), override = TRUE)
+	RegisterSignal(charger, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_dir_change), override = TRUE)
 	set_toggle(TRUE)
 	if(verbose)
 		to_chat(charger, span_xenonotice("We will charge when moving, now."))


### PR DESCRIPTION
## `Основные изменения`

Убрал дублирующийся звук у примо и мелкие рантаймы.

![Снимок экрана 2024-10-17 173207](https://github.com/user-attachments/assets/80ec7692-0ffb-4f7c-b77a-ddca8be95c85)
![Снимок экрана 2024-10-17 173215](https://github.com/user-attachments/assets/2239f5b3-ca70-4b72-8b33-9cf1c2d09850)

## `Как это улучшит игру`

Баг фикс.

## `Ченджлог`

Убрал дублирование звука у примо и мелкие рантаймы.
```
:cl:
fix: Исправил дублирование звука у примо крашера.
fix: Исправил два рантайма, которые появлялись после каждого использования абилки.
/:cl:
```
