### PR TITLE
Proper lights for optable and bioprinter, so their emissives are seen.

### DIFF
--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -15,6 +15,8 @@
 	active_power_usage = 5
 	buckle_flags = CAN_BUCKLE
 	buckle_lying = 90
+	light_power = 0.2
+	light_range = 0.4
 	var/mob/living/carbon/human/victim = null
 	var/strapped = 0
 	var/obj/item/tank/anesthetic/anes_tank
@@ -40,6 +42,14 @@
 /obj/machinery/optable/Destroy()
 	computer = null
 	return ..()
+
+/obj/machinery/optable/update_icon_state()
+	. = ..()
+
+	if(machine_stat & (BROKEN|DISABLED|NOPOWER))
+		set_light(0, 0)
+	else
+		set_light(initial(light_range), initial(light_power))
 
 /obj/machinery/optable/update_overlays()
 	. = ..()

--- a/code/game/objects/machinery/bioprinter.dm
+++ b/code/game/objects/machinery/bioprinter.dm
@@ -10,7 +10,7 @@
 	icon_state = "bioprinter"
 
 	light_range = 0.5
-	light_power = 0.5
+	light_power = 0.4
 
 	var/working = 0
 	var/stored_matter = 0

--- a/code/game/objects/machinery/bioprinter.dm
+++ b/code/game/objects/machinery/bioprinter.dm
@@ -9,6 +9,9 @@
 
 	icon_state = "bioprinter"
 
+	light_range = 0.5
+	light_power = 0.5
+
 	var/working = 0
 	var/stored_matter = 0
 	var/stored_metal = 0
@@ -84,11 +87,13 @@
 	. = ..()
 	if(machine_stat & NOPOWER)
 		icon_state = "bioprinter_off"
+		set_light(0, 0)
 		return
 	if(working)
 		icon_state = "bioprinter_busy"
 	else
 		icon_state = "bioprinter"
+	set_light(initial(light_range), initial(light_power))
 
 /obj/machinery/bioprinter/update_overlays()
 	. = ..()


### PR DESCRIPTION
## `Основные изменения`
Светящиеся элементы биопринтера и операционного стола теперь видно в темноте.
## `Ченджлог`
```
:cl:
fix: Светящиеся элементы биопринтера и операционного стола теперь видно в темноте.
/:cl:
```
