### PR TITLE
Cas weaponry doesn't fit on other shuttles now.

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -240,6 +240,12 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define DROPPOD_ACTIVE 2
 #define DROPPOD_LANDED 3
 
+#define DROPSHIP_WEAPON "dropship_weapon"
+#define DROPSHIP_CREW_WEAPON "dropship_crew_weapon"
+#define DROPSHIP_ELECTRONICS "dropship_electronics"
+#define DROPSHIP_FUEL_EQP "dropship_fuel_equipment"
+#define DROPSHIP_COMPUTER "dropship_computer"
+
 ///Burn level applied by lava if it calls fire_act
 #define LAVA_BURN_LEVEL 60
 

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -241,6 +241,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define DROPPOD_LANDED 3
 
 #define DROPSHIP_WEAPON "dropship_weapon"
+#define DROPSHIP_WEAPON_CAS "dropship_weapon_cas"
 #define DROPSHIP_CREW_WEAPON "dropship_crew_weapon"
 #define DROPSHIP_ELECTRONICS "dropship_electronics"
 #define DROPSHIP_FUEL_EQP "dropship_fuel_equipment"

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -61,7 +61,6 @@
 
 	loaded_equipment.update_equipment()
 
-
 /obj/effect/attach_point/weapon
 	name = "weapon system attach point"
 	icon_state = "equip_base_front"
@@ -77,6 +76,7 @@
 
 /obj/effect/attach_point/weapon/cas
 	ship_tag = SHUTTLE_CAS_DOCK
+	base_category = DROPSHIP_WEAPON_CAS
 	icon = 'icons/Marine/casship.dmi'
 	icon_state = "15"
 
@@ -627,7 +627,7 @@
 /obj/structure/dropship_equipment/cas/weapon
 	name = "abstract weapon"
 	icon = 'icons/Marine/mainship_props64.dmi'
-	equip_category = DROPSHIP_WEAPON
+	equip_category = DROPSHIP_WEAPON_CAS
 	bound_width = 32
 	bound_height = 64
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE|FIRE_MISSION_ONLY

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -1,13 +1,3 @@
-
-#define DROPSHIP_WEAPON "dropship_weapon"
-#define DROPSHIP_CREW_WEAPON "dropship_crew_weapon"
-#define DROPSHIP_ELECTRONICS "dropship_electronics"
-#define DROPSHIP_FUEL_EQP "dropship_fuel_equipment"
-#define DROPSHIP_COMPUTER "dropship_computer"
-
-
-//the bases onto which you attach dropship equipments.
-
 /obj/effect/attach_point
 	name = "equipment attach point"
 	desc = "A place where heavy equipment can be installed with a powerloader."


### PR DESCRIPTION
## `Основные изменения`
Орудия для каса больше нельзя прикрепить к другим шаттлам.
## `Ченджлог`
```
:cl:
fix: Орудия для каса больше нельзя прикрепить к другим шаттлам.
/:cl:
```
