### PR TITLE
You can't evolve into limited next tiers, with caste swap\regress.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -8,6 +8,7 @@
 	set desc = "Evolve into a higher form."
 	set category = "Alien"
 
+	SStgui.close_user_uis(src, GLOB.evo_panel)
 	GLOB.evo_panel.ui_interact(src)
 
 /mob/living/carbon/xenomorph/verb/caste_swap()
@@ -19,6 +20,7 @@
 		to_chat(src, span_warning("Your caste swap timer is not done yet."))
 		return
 
+	SStgui.close_user_uis(src, GLOB.evo_panel)
 	ADD_TRAIT(src, TRAIT_CASTE_SWAP, TRAIT_CASTE_SWAP)
 	GLOB.evo_panel.ui_interact(src)
 
@@ -40,6 +42,7 @@
 	set desc = "Regress into a lower form."
 	set category = "Alien"
 
+	SStgui.close_user_uis(src, GLOB.evo_panel)
 	ADD_TRAIT(src, TRAIT_REGRESSING, TRAIT_REGRESSING)
 	GLOB.evo_panel.ui_interact(src)
 


### PR DESCRIPTION
## `Основные изменения`
Фиксит вот это:
![image](https://github.com/user-attachments/assets/c08e3743-9b1c-43ff-8032-b1cbf7c472d7)
## `Ченджлог`
```
:cl:
fix: Теперь нельзя эволюционировать обходя лимит тиров с помощью регресса/каст свапа.
/:cl:
```
