### PR TITLE
Change larvapoints from shipside roles

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(jobs_fallen_marine, typecacheof(list(/datum/job/fallen/marine),
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 0.5
 #define LARVA_POINTS_SHIPSIDE_STRONG 1.5
-#define LARVA_POINTS_REGULAR 2.7
+#define LARVA_POINTS_REGULAR 3.25
 #define LARVA_POINTS_STRONG 6
 
 #define SURVIVOR_POINTS_REGULAR 1

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(jobs_fallen_marine, typecacheof(list(/datum/job/fallen/marine),
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 0.5
 #define LARVA_POINTS_SHIPSIDE_STRONG 1.5
-#define LARVA_POINTS_REGULAR 3.25
+#define LARVA_POINTS_REGULAR 2.7
 #define LARVA_POINTS_STRONG 6
 
 #define SURVIVOR_POINTS_REGULAR 1

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(jobs_fallen_marine, typecacheof(list(/datum/job/fallen/marine),
 #define XP_REQ_EXPERT 3600
 
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
-#define LARVA_POINTS_SHIPSIDE 1
+#define LARVA_POINTS_SHIPSIDE 0.5
 #define LARVA_POINTS_SHIPSIDE_STRONG 1.5
 #define LARVA_POINTS_REGULAR 3.25
 #define LARVA_POINTS_STRONG 6


### PR DESCRIPTION
## `Основные изменения`
Снизил с 1 до 0.5 генерацию лярвапоинтов для небоевых ролей шипсайда(кроме синта, пилотов)

## `Как это улучшит игру`
Шипсайд не сражается на земле > меньше влияния шипсайда на количество беносов на планете

## `Ченджлог`
```
:cl:
balance: Генерация лярвапоинтов с небоевых шипсайд ролей снижена с 1 до 0.5
/:cl:
```
