### PR TITLE
Баффы арты

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -939,8 +939,7 @@
 	desc = "A large case containing rockets in a compressed setting for the TA-40L MLRS. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
 	storage_slots = 16
 
-/obj/item/storage/box/mlrs_rockets/Initialize(mapload)
-	. = ..()
+/obj/item/storage/box/mlrs_rockets/PopulateContents()
 	for(var/i in 1 to 16)
 		new /obj/item/mortal_shell/rocket/mlrs(src)
 
@@ -949,8 +948,7 @@
 	desc = "A large case containing rockets in a compressed setting for the TA-40L MLRS. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
 	storage_slots = 16
 
-/obj/item/storage/box/mlrs_rockets_gas/Initialize(mapload)
-	. = ..()
+/obj/item/storage/box/mlrs_rockets_gas/PopulateContents()
 	for(var/i in 1 to 16)
 		new /obj/item/mortal_shell/rocket/mlrs/gas(src)
 
@@ -959,8 +957,7 @@
 	desc = "A large case containing rockets in a compressed setting for the TA-40L MLRS. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
 	storage_slots = 16
 
-/obj/item/storage/box/mlrs_rockets_tangle/Initialize(mapload)
-	. = ..()
+/obj/item/storage/box/mlrs_rockets_tangle/PopulateContents()
 	for(var/i in 1 to 16)
 		new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -785,7 +785,7 @@
 
 /obj/item/mortal_shell/rocket/mlrs/tangle
 	name = "\improper 60mm 'T-33' rocket"
-	desc = "A 60mm rocket loaded with tanglefoot gas that drains plasma from benoses."
+	desc = "A 60mm rocket loaded with tanglefoot gas that drains plasma from xeno."
 	icon_state = "mlrs_rocket_gas"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/tangle
 

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -941,22 +941,8 @@
 
 /obj/item/storage/box/mlrs_rockets/Initialize(mapload)
 	. = ..()
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
-	new /obj/item/mortal_shell/rocket/mlrs(src)
+	for(var/i in 1 to 16)
+		new /obj/item/mortal_shell/rocket/mlrs(src)
 
 /obj/item/storage/box/mlrs_rockets_gas
 	name = "\improper TA-40L X-50 rocket crate"
@@ -965,22 +951,8 @@
 
 /obj/item/storage/box/mlrs_rockets_gas/Initialize(mapload)
 	. = ..()
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
-	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
+	for(var/i in 1 to 16)
+		new /obj/item/mortal_shell/rocket/mlrs/gas(src)
 
 /obj/item/storage/box/mlrs_rockets_tangle
 	name = "\improper TA-40L T-33 rocket crate"
@@ -989,22 +961,8 @@
 
 /obj/item/storage/box/mlrs_rockets_tangle/Initialize(mapload)
 	. = ..()
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
-	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	for(var/i in 1 to 16)
+		new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
 
 #undef TALLY_MORTAR
 #undef TALLY_HOWITZER

--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -539,7 +539,7 @@
 	tally_type = TALLY_HOWITZER
 	cool_off_time = 10 SECONDS
 	reload_time = 1 SECONDS
-	max_spread = 8
+	max_spread = 2
 
 /obj/machinery/deployable/mortar/howitzer/AltRightClick(mob/living/user)
 	if(!Adjacent(user) || user.lying_angle || user.incapacitated() || !ishuman(user))
@@ -614,20 +614,21 @@
 	fire_sound = 'sound/weapons/guns/fire/rocket_arty.ogg'
 	reload_sound = 'sound/weapons/guns/interact/tat36_reload.ogg'
 	fall_sound = 'sound/weapons/guns/misc/rocket_whistle.ogg'
-	minimum_range = 25
+	minimum_range = 20
 	allowed_shells = list(
 		/obj/item/mortal_shell/rocket/mlrs,
 		/obj/item/mortal_shell/rocket/mlrs/gas,
+		/obj/item/mortal_shell/rocket/mlrs/tangle,
 	)
 	tally_type = TALLY_ROCKET_ARTY
-	cool_off_time = 80 SECONDS
+	cool_off_time = 60 SECONDS
 	fire_delay = 0.15 SECONDS
 	fire_amount = 16
 	reload_time = 0.25 SECONDS
 	max_rounds = 32
 	offset_per_turfs = 25
-	spread = 5
-	max_spread = 5
+	spread = 3.5
+	max_spread = 6.5
 
 //this checks for box of rockets, otherwise will go to normal attackby for mortars
 /obj/machinery/deployable/mortar/howitzer/mlrs/attackby(obj/item/I, mob/user, params)
@@ -635,7 +636,7 @@
 		user.balloon_alert(user, "The barrel is steaming hot. Wait till it cools off")
 		return
 
-	if(!istype(I, /obj/item/storage/box/mlrs_rockets) && !istype(I, /obj/item/storage/box/mlrs_rockets_gas))
+	if(!istype(I, /obj/item/storage/box/mlrs_rockets) && !istype(I, /obj/item/storage/box/mlrs_rockets_gas) && !istype(I, /obj/item/storage/box/mlrs_rockets_tangle))
 		return ..()
 
 	var/obj/item/storage/box/rocket_box = I
@@ -781,6 +782,12 @@
 	desc = "A 60mm rocket loaded with deadly X-50 gas that drains the energy and life out of anything unfortunate enough to find itself inside of it."
 	icon_state = "mlrs_rocket_gas"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs
+
+/obj/item/mortal_shell/rocket/mlrs/tangle
+	name = "\improper 60mm 'T-33' rocket"
+	desc = "A 60mm rocket loaded with tanglefoot gas that drains plasma from benoses."
+	icon_state = "mlrs_rocket_gas"
+	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/tangle
 
 /obj/structure/closet/crate/mortar_ammo
 	name = "\improper T-50S mortar ammo crate"
@@ -974,6 +981,30 @@
 	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
 	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
 	new /obj/item/mortal_shell/rocket/mlrs/gas(src)
+
+/obj/item/storage/box/mlrs_rockets_tangle
+	name = "\improper TA-40L T-33 rocket crate"
+	desc = "A large case containing rockets in a compressed setting for the TA-40L MLRS. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
+	storage_slots = 16
+
+/obj/item/storage/box/mlrs_rockets_tangle/Initialize(mapload)
+	. = ..()
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
+	new /obj/item/mortal_shell/rocket/mlrs/tangle(src)
 
 #undef TALLY_MORTAR
 #undef TALLY_HOWITZER

--- a/code/modules/projectiles/ammo_datums/artillery.dm
+++ b/code/modules/projectiles/ammo_datums/artillery.dm
@@ -53,7 +53,7 @@
 	icon_state = "howi"
 
 /datum/ammo/mortar/howi/drop_nade(turf/T)
-	cell_explosion(T, 175, 50)
+	cell_explosion(T, 200, 100)
 
 /datum/ammo/mortar/howi/incend/drop_nade(turf/T)
 	cell_explosion(T, 45, 30)
@@ -96,7 +96,7 @@
 
 /datum/ammo/mortar/rocket/incend/drop_nade(turf/T)
 	cell_explosion(T, 50, 20)
-	flame_radius(5, T)
+	flame_radius(6, T)
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
 /datum/ammo/mortar/rocket/minelayer/drop_nade(turf/T)

--- a/code/modules/projectiles/ammo_datums/artillery.dm
+++ b/code/modules/projectiles/ammo_datums/artillery.dm
@@ -115,18 +115,30 @@
 	smoke.start()
 
 /datum/ammo/mortar/rocket/mlrs
-	shell_speed = 2.5
+	shell_speed = 3
 
 /datum/ammo/mortar/rocket/mlrs/drop_nade(turf/T)
 	cell_explosion(T, 70, 25)
 
 /datum/ammo/mortar/rocket/smoke/mlrs
-	shell_speed = 2.5
+	shell_speed = 3
 	smoketype = /datum/effect_system/smoke_spread/mustard
 
 /datum/ammo/mortar/rocket/smoke/mlrs/drop_nade(turf/T)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
 	cell_explosion(T, 30, 15)
+	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(5, T, 6)
+	flame_radius(4, T)
+	smoke.start()
+
+/datum/ammo/mortar/rocket/smoke/mlrs/tangle
+	shell_speed = 3
+	smoketype = /datum/effect_system/smoke_spread/plasmaloss
+
+/datum/ammo/mortar/rocket/smoke/mlrs/tangle/drop_nade(turf/T)
+	var/datum/effect_system/smoke_spread/smoke = new smoketype()
+	cell_explosion(T, 10, 2)
 	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(5, T, 6)
 	smoke.start()

--- a/code/modules/reqs/explosives.dm
+++ b/code/modules/reqs/explosives.dm
@@ -133,22 +133,27 @@
 /datum/supply_packs/explosives/mlrs_rockets
 	name = "TA-40L MLRS Rocket Pack (x16)"
 	contains = list(/obj/item/storage/box/mlrs_rockets)
-	cost = 60
+	cost = 40
 
 /datum/supply_packs/explosives/mlrs_rockets_gas
 	name = "TA-40L X-50 MLRS Rocket Pack (x16)"
 	contains = list(/obj/item/storage/box/mlrs_rockets_gas)
-	cost = 60
+	cost = 50
+
+/datum/supply_packs/explosives/mlrs_rockets_tangle
+	name = "TA-40L T-33 MLRS Rocket Pack (x16)"
+	contains = list(/obj/item/storage/box/mlrs_rockets_tangle)
+	cost = 50
 
 /datum/supply_packs/explosives/ai_target_module
 	name = "AI artillery targeting module"
 	contains = list(/obj/item/ai_target_beacon)
-	cost = 100
+	cost = 50
 
 /datum/supply_packs/explosives/knee_mortar
 	name = "T-10K Knee Mortar"
 	contains = list(/obj/item/mortar_kit/knee)
-	cost = 125
+	cost = 50
 
 /datum/supply_packs/explosives/knee_mortar_ammo
 	name = "TA-10K knee mortar HE shell"
@@ -164,24 +169,24 @@
 /datum/supply_packs/explosives/howitzer
 	name = "TA-100Y howitzer"
 	contains = list(/obj/item/mortar_kit/howitzer)
-	cost = 600
+	cost = 500
 
 /datum/supply_packs/explosives/howitzer_ammo_he
 	name = "TA-100Y howitzer HE shell"
 	contains = list(/obj/item/mortal_shell/howitzer/he)
-	cost = 40
+	cost = 30
 
 /datum/supply_packs/explosives/howitzer_ammo_incend
 	name = "TA-100Y howitzer incendiary shell"
 	contains = list(/obj/item/mortal_shell/howitzer/incendiary)
-	cost = 40
+	cost = 30
 
 /datum/supply_packs/explosives/howitzer_ammo_wp
 	name = "TA-100Y howitzer white phosporous smoke shell"
 	contains = list(/obj/item/mortal_shell/howitzer/white_phos)
-	cost = 60
+	cost = 45
 
 /datum/supply_packs/explosives/howitzer_ammo_plasmaloss
 	name = "TA-100Y howitzer tanglefoot shell"
 	contains = list(/obj/item/mortal_shell/howitzer/plasmaloss)
-	cost = 60
+	cost = 45


### PR DESCRIPTION
## `Основные изменения`
Дал богам войны больше веселья
Ховайзер:
Теперь ховайзер может делать больно только при умелом использовании вебмапы или при хорошем наводчике, но делает намного больнее чем раньше

МЛРС теперь лучше накрывает площади, снаряды подешевле, Х-50 теперь еще и зажигательные помимо газа, добавлены тенгл снаряды с ЛХЕ функцией

А миномет, вроде, итак со своей задачей хорошо справляется

## `Как это улучшит игру`
Будет веселее
> Миномет: около-унивенсальное оружие. Имеет меньшее покрытие газами и огнем, чем РСЗО, и меньший урон, чем гаубица, но может выполнять оба функционала.
Гаубица: высокий урон от бабахов
РСЗО: покрытие большой площади зажигательными снарядами, тгазом, дымами, светом

https://discord.com/channels/1235677154084126861/1244698886753222818/1288370849698680882

## `Ченджлог`
```
:cl:
add: Тенглфут снаряды для РСЗО в карго.
balance: Добавил фугасности ХЕ снаряду ховайзера.
balance: РСЗО имеет больший разброс.
balance: Снижен кулдаун на стрельбу РСЗО.
balance: Гаубица имеет меньший разброс.
balance: Артиллерийские боеприпасы теперь стоят меньше в карго.
/:cl:
```