### PR TITLE
Rebalance xeno HP and armor

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -29,7 +29,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 20, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 50, BIO = 50, FIRE = 20, ACID = 50)
-	hard_armor = list(MELEE = 0, BULLET = 12, LASER = 12, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 12, LASER = 0, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "behemoth"

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -29,7 +29,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 20, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 50, BIO = 50, FIRE = 20, ACID = 50)
-	hard_armor = list(MELEE = 0, BULLET = 12, LASER = 0, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 12, LASER = 6, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "behemoth"

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/castedatum_behemoth.dm
@@ -29,7 +29,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 20, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 50, BIO = 50, FIRE = 20, ACID = 50)
-	hard_armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 12, LASER = 12, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "behemoth"

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 630
+	max_health = 500
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -21,14 +21,14 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 630
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 	caste_traits = list(TRAIT_STOPS_TANK_COLLISION)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 90, BULLET = 80, LASER = 80, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 10, ACID = 100)
+	soft_armor = list(MELEE = 50, BULLET = 80, LASER = 80, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 10, ACID = 100)
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -28,7 +28,7 @@
 	caste_traits = list(TRAIT_STOPS_TANK_COLLISION)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 50, BULLET = 80, LASER = 80, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 10, ACID = 100)
+	soft_armor = list(MELEE = 50, BULLET = 80, LASER = 65, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 10, ACID = 100)
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -33,7 +33,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 40, BULLET = 45, LASER = 45, ENERGY = 40, BOMB = 20, BIO = 30, FIRE = 10, ACID = 30)
-	hard_armor = list(MELEE = 0, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	hard_armor = list(MELEE = 0, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defender"

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 320
+	max_health = 410
 
 	// *** Evolution *** //
 	evolution_threshold = 100
@@ -33,6 +33,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 40, BULLET = 45, LASER = 45, ENERGY = 40, BOMB = 20, BIO = 30, FIRE = 10, ACID = 30)
+	hard_armor = list(MELEE = 0, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defender"

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 80
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 570
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_HOLD_JELLY

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -19,14 +19,14 @@
 	plasma_gain = 80
 
 	// *** Health *** //
-	max_health = 460
+	max_health = 590
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_HOLD_JELLY
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 45, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 20, ACID = 40)
+	soft_armor = list(MELEE = 45, BULLET = 25, LASER = 25, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 20, ACID = 40)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -26,7 +26,7 @@
 	caste_traits = null
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 45, BULLET = 25, LASER = 25, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 20, ACID = 40)
+	soft_armor = list(MELEE = 45, BULLET = 25, LASER = 15, ENERGY = 50, BOMB = 10, BIO = 40, FIRE = 20, ACID = 40)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 80
 
 	// *** Health *** //
-	max_health = 590
+	max_health = 500
 
 	// *** Flags *** //
 	can_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_HOLD_JELLY

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 21
 
 	// *** Health *** //
-	max_health = 450
+	max_health = 400
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 21
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 450
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 310
+	max_health = 510
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -30,7 +30,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 25, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 10, ACID = 20)
+	soft_armor = list(MELEE = 25, BULLET = 20, LASER = 20, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 10, ACID = 20)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "spitter"

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -30,7 +30,7 @@
 	caste_traits = list(TRAIT_CAN_VENTCRAWL)
 
 	// *** Defense *** //
-	soft_armor = list(MELEE = 25, BULLET = 20, LASER = 20, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 10, ACID = 20)
+	soft_armor = list(MELEE = 25, BULLET = 20, LASER = 10, ENERGY = 35, BOMB = 0, BIO = 20, FIRE = 10, ACID = 20)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "spitter"

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,7 +19,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 510
+	max_health = 450
 
 	// *** Evolution *** //
 	evolution_threshold = 225


### PR DESCRIPTION
## `Основные изменения`
Изменил статы ХП и/или армора у большей части каст.

## `Как это улучшит игру`
Более явное разделение на беносов, против которых вариативно использование ХП/АП патронов.
Повышение выживаемости и/или играбельности танков.
Повышение играбельности лазерок.

## `Ченджлог`
```
:cl:
balance: Бегемот получил 12 харда от буллета, потерял хард от мили, снижен хард от лазеров с 12 до 6
balance: Крашеру поднято ХП с 400 до 500, понерфлен софтармор от мили с 80 до 50, лазеры с 80 до 65
balance: Дефендеру поднято ХП с 320 до 410, получил хардармор 10 от буллета
balance: Претору поднято ХП с 460 до 570, снижен софтармор буллета с 50 до 25, лазеров с 50 до 15
balance: Сентинелю поднято ХП с 300 до 400
balance: Спиттеру поднято ХП с 310 до 450, софтармор буллета снижен с 35 до 20, лазеров с 35 до 10
/:cl:
```