### PR TITLE
Change wall flame pen and add wide spray

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -165,6 +165,7 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
+			/obj/item/attachable/flamer_nozzle/wide = -1,
 			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
@@ -375,6 +376,7 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
+			/obj/item/attachable/flamer_nozzle/wide = -1,
 			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(
@@ -621,6 +623,7 @@
 			/obj/item/ammo_magazine/rifle/pepperball/pepperball_mini = -1,
 			/obj/item/attachable/stock/t76 = -1,
 			/obj/item/attachable/flamer_nozzle = -1,
+			/obj/item/attachable/flamer_nozzle/wide = -1,
 			/obj/item/attachable/flamer_nozzle/long = -1,
 		),
 		"Boxes" = list(

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -59,9 +59,9 @@
 	///Max range of the flamer in tiles.
 	var/flame_max_range = 6
 	///Max resin wall penetration in tiles.
-	var/flame_max_wall_pen = 2
+	var/flame_max_wall_pen = 3
 	///After how many total resin walls the flame wont proceed further
-	var/flame_max_wall_pen_wide = 9
+	var/flame_max_wall_pen_wide = 7
 	///Travel speed of the flames in seconds.
 	var/flame_spread_time = 0.1 SECONDS
 	///Gun based modifier for burn level. Percentage based.


### PR DESCRIPTION
## `Основные изменения`
Вернул спрей насадку
Обычная насадка прожигает до 3 стен
Спрей насадка прожигает до 7 стен

## `Как это улучшит игру`
Фидбек + бафф очевидно слабых огнеметов

## `Ченджлог`
```
:cl:
balance: Спрей-насадка возвращена в вендор оружия
balance: Спрей насадка прожигает до 7 стенок вместо 9
balance: Обычная насадка прожигает до 3 стенок вместо 2
/:cl:
```
