### PR TITLE
Nerfs explosion throw.

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -260,7 +260,7 @@ explosion resistance exactly as much as their health
 
 	if(!direction)
 		direction = pick(GLOB.alldirs)
-	var/range = min(round(severity * 0.05, 1), 14)
+	var/range = min(round(severity * 0.07, 1), 14)
 	if(!direction)
 		range = round(range * 0.5, 1)
 

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -260,18 +260,18 @@ explosion resistance exactly as much as their health
 
 	if(!direction)
 		direction = pick(GLOB.alldirs)
-	var/range = min(round(severity * 0.2, 1), 14)
+	var/range = min(round(severity * 0.05, 1), 14)
 	if(!direction)
 		range = round(range * 0.5, 1)
 
 	if(range < 1)
 		return
 
-	var/speed = max(range * 2.5, 4)
+	var/speed = max(range, 3)
 	var/atom/target = get_ranged_target_turf(src, direction, range)
 
 	if(range >= 2)
-		var/scatter = range / 4 * scatter_multiplier
+		var/scatter = range * 0.25 * scatter_multiplier
 		var/scatter_x = rand(-scatter, scatter)
 		var/scatter_y = rand(-scatter, scatter)
 		target = locate(target.x + round(scatter_x, 1), target.y + round(scatter_y, 1), target.z) //Locate an adjacent turf.


### PR DESCRIPTION
## `Основные изменения`
`var/range = min(round(severity * 0.2, 1), 14)` было сделано так что ранж меньше 14, у тебя был только если взрыв был слабее 70, когда в тех же м40 гранатах сила взрыва 115.
Изменено на `var/range = min(round(severity * 0.07, 1), 14)`

Скорость была в виде `var/speed = max(range * 2.5, 4)`, что с учётом вечного ренжа в 14, множила её в 2.5 раза, из чего получалось что урон от броска множился на 35, потом делился на 5, и получалось что с броска копья с уроном в 45 урона, тебе прилетало 315 урона. Что сразу отрубает конечности, голову и делает перелом с ИБ. И ничто не мешает это дело стакать для лучшего эффекта.
Изменено на `var/speed = max(range, 3)`
## `Как это улучшит игру`
Взрывные ловушки станут чуть адекватнее.
## `Ченджлог`
```
:cl:
balance: Понёрфил силу отбрасывания от взрывов.
/:cl:
```
