### PR TITLE
sr127 nerf

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -389,7 +389,7 @@
 		/obj/item/weapon/gun/shotgun/pump/trenchgun,
 		/obj/item/weapon/gun/flamer/big_flamer,
 		/obj/item/weapon/gun/pistol/auto9,
-		/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127,
+		/obj/item/weapon/gun/rifle/sr127,
 		/obj/item/weapon/gun/rifle/ar11,
 		/obj/item/weapon/gun/rifle/ar21,
 		/obj/item/weapon/gun/rifle/mkh,

--- a/code/game/objects/effects/spawners/random/random_set.dm
+++ b/code/game/objects/effects/spawners/random/random_set.dm
@@ -72,7 +72,7 @@
 			/obj/item/ammo_magazine/rifle/br64,
 			/obj/item/ammo_magazine/rifle/br64,
 		),
-		list(/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127,
+		list(/obj/item/weapon/gun/rifle/sr127,
 			/obj/item/ammo_magazine/rifle/sr127,
 			/obj/item/ammo_magazine/rifle/sr127,
 			/obj/item/ammo_magazine/rifle/sr127,

--- a/code/game/objects/effects/spawners/random/weaponry.dm
+++ b/code/game/objects/effects/spawners/random/weaponry.dm
@@ -14,7 +14,7 @@
 		/obj/item/weapon/gun/rifle/type71,
 		/obj/item/weapon/gun/rifle/dmr37,
 		/obj/item/weapon/gun/rifle/br64,
-		/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127,
+		/obj/item/weapon/gun/rifle/sr127,
 		/obj/item/weapon/gun/shotgun/pump/bolt/unscoped,
 		/obj/item/weapon/gun/shotgun/double/martini,
 		/obj/item/weapon/gun/pistol/p14,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -37,7 +37,7 @@
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/dmr37 = -1,
 			/obj/item/ammo_magazine/rifle/dmr37 = -1,
-			/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127= -1,
+			/obj/item/weapon/gun/rifle/sr127= -1,
 			/obj/item/ammo_magazine/rifle/sr127 = -1,
 			/obj/item/weapon/gun/rifle/sniper/svd = -1,
 			/obj/item/ammo_magazine/sniper/svd = -1,
@@ -263,7 +263,7 @@
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/dmr37 = -1,
 			/obj/item/ammo_magazine/rifle/dmr37 = -1,
-			/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127= -1,
+			/obj/item/weapon/gun/rifle/sr127= -1,
 			/obj/item/ammo_magazine/rifle/sr127 = -1,
 			/obj/item/weapon/gun/revolver/r44/coltrifle = -1,
 			/obj/item/ammo_magazine/revolver/rifle = -1,
@@ -480,7 +480,7 @@
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/dmr37 = -1,
 			/obj/item/ammo_magazine/rifle/dmr37 = -1,
-			/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127= -1,
+			/obj/item/weapon/gun/rifle/sr127= -1,
 			/obj/item/ammo_magazine/rifle/sr127 = -1,
 			/obj/item/weapon/gun/rifle/sniper/svd = -1,
 			/obj/item/ammo_magazine/sniper/svd = -1,

--- a/code/modules/projectiles/ammo_datums/bullet/sniper.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/sniper.dm
@@ -95,10 +95,10 @@
 	name = "high caliber rifle bullet"
 	hud_state = "sniper_heavy"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER
-	damage = 75
+	damage = 65
 	penetration = 30
 	sundering = 0
-	additional_xeno_penetration = 15
+	additional_xeno_penetration = 10
 	damage_falloff = 0.25
 
 /datum/ammo/bullet/sniper/pfc/on_hit_mob(mob/M, obj/projectile/P)

--- a/code/modules/projectiles/ammo_datums/bullet/sniper.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/sniper.dm
@@ -96,13 +96,10 @@
 	hud_state = "sniper_heavy"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER
 	damage = 65
-	penetration = 30
+	penetration = 20
 	sundering = 0
-	additional_xeno_penetration = 10
+	additional_xeno_penetration = 5
 	damage_falloff = 0.25
-
-/datum/ammo/bullet/sniper/pfc/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, slowdown = 1, max_range = 17)
 
 /datum/ammo/bullet/sniper/pfc/flak
 	name = "high caliber flak rifle bullet"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1549,7 +1549,7 @@
 	)
 
 	burst_amount = 0
-	fire_delay = 1.35 SECONDS
+	fire_delay = 2.6 SECONDS
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.7
 	scatter = -5
@@ -1558,7 +1558,6 @@
 	recoil_unwielded = 4
 	aim_slowdown = 1
 	wield_delay = 1.3 SECONDS
-	cock_delay = 0.7 SECONDS
 	movement_acc_penalty_mult = 6
 
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1493,7 +1493,7 @@
 //SR-127 bolt action sniper rifle
 
 
-/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127 //its a subtype of antimaterial. A little complicated, but I don't want to copypast
+/obj/item/weapon/gun/rifle/sr127
 	name = "\improper SR-127 Bauer bolt action rifle"
 	desc = "The Bauer SR-127 is the standard issue bolt action rifle used by the TGMC. Known for its long range accuracy and use by marksmen despite its age and lack of IFF, though careful aim allows fire support from behind. It has an irremoveable scope. Uses 8.6×70mm box magazines."
 	icon = 'icons/Marine/gun64.dmi'
@@ -1513,6 +1513,7 @@
 	reload_sound =   'sound/weapons/guns/sniper/SR-127/SR127_clipin.ogg'
 	silenced_sound = 'sound/weapons/guns/sniper/SR-127/SR127_SIL.ogg'
 	wield_sound =    'sound/weapons/guns/dmr/Deploy_Wave_DMR.ogg'
+	cocked_sound =   'sound/weapons/guns/sniper/SR-127/SR127_boltpull.ogg'
 	caliber = CALIBER_86X70 //codex
 	max_shells = 10 //codex
 	default_ammo_type = /obj/item/ammo_magazine/rifle/sr127
@@ -1534,6 +1535,7 @@
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER|GUN_SMOKE_PARTICLES
+	reciever_flags = AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION|AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_UNIQUE_ACTION_LOCKS|AMMO_RECIEVER_AUTO_EJECT
 
 	cock_animation = "tl127_cock"
 	cocked_message = "You rack the bolt!"
@@ -1549,7 +1551,7 @@
 	)
 
 	burst_amount = 0
-	fire_delay = 2.6 SECONDS
+	fire_delay = 1.35 SECONDS
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.7
 	scatter = -5
@@ -1558,10 +1560,11 @@
 	recoil_unwielded = 4
 	aim_slowdown = 1
 	wield_delay = 1.3 SECONDS
+	cock_delay = 0.7 SECONDS
 	movement_acc_penalty_mult = 6
 
 
-/obj/item/weapon/gun/rifle/sniper/antimaterial/sr127/unscoped
+/obj/item/weapon/gun/rifle/sr127/unscoped
 	starting_attachment_types = list(/obj/item/attachable/stock/sr127stock)
 
 //-------------------------------------------------------


### PR DESCRIPTION
## `Основные изменения`

Нерф болтовки

## `Как это улучшит игру`

БАЛАНС. Сейчас болтовка стреляет в два раза быстрее антиматериалки(которая стоит в карго 800 поинтов) и имеет примерно такой же как у нее урон.

Охуенно когда стоковая пушка по статам равна карговской.

## `Ченджлог`

Лазермод удален, так как слишком много дает.
Убрал замедление у обычных пуль.

Урон 75 -> 65
АП 30 -> 20
Дополнительное АП 15 -> 5
```
:cl:
balance: Нерф sr27: удалил лазер таргетинг
balance: Нерф sr27: урон 75 -> 65, АП 30 -> 20, Дополнительное АП 15 -> 5
balance: Нерф sr27: пули больше не замедляют
/:cl:
```
