### PR TITLE
Ксенодверям надо 2 тайла между собой для постройки

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -364,8 +364,13 @@
 			return
 
 	if(X.selected_resin == /obj/structure/bed/nest)
-		for(var/obj/structure/bed/nest/xeno_nest in range (2,T))
+		for(var/obj/structure/bed/nest/xeno_nest in range(2, T))
 			owner.balloon_alert(owner, span_notice("Another nest is too close!"))
+			return
+
+	if(X.selected_resin == /obj/structure/mineral_door/resin)
+		for(var/obj/structure/mineral_door/resin/door in range(2, T))
+			owner.balloon_alert(owner, span_notice("Another door is too close!"))
 			return
 
 	var/atom/new_resin
@@ -389,6 +394,10 @@
 	if(X.selected_resin == /obj/structure/bed/nest)
 		for(var/obj/structure/bed/nest/xeno_nest in range (2, T))
 			owner.balloon_alert(owner, span_notice("Another nest is too close!"))
+			return
+	if(X.selected_resin == /obj/structure/mineral_door/resin)
+		for(var/obj/structure/mineral_door/resin/door in range(2, T))
+			owner.balloon_alert(owner, span_notice("Another door is too close!"))
 			return
 	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin))
 		if(ERROR_CANT_WEED)


### PR DESCRIPTION
## `Основные изменения`

Между дверьми теперь должно быть минимум 2 тайла для их постройки

## `Как это улучшит игру`

Не будет раковых застроек всего дверьми, отвратительных по многим причинам.

## `Ченджлог`

```
:cl:
balance: Теперь между ксенодверьми должно быть минимум 2 тайла для их постройки.
/:cl:
```