### PR TITLE
Tank high pop lock

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -20,7 +20,7 @@
 		/datum/job/terragov/civilian/clown = -1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
-		/datum/job/terragov/command/assault_crewman = 2,
+		/datum/job/terragov/command/assault_crewman = 0,
 		/datum/job/terragov/command/transport_crewman = 1,
 		/datum/job/terragov/silicon/ai = 1,
 		/datum/job/terragov/squad/engineer = 8,

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -20,7 +20,7 @@
 		/datum/job/terragov/civilian/clown = -1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
-		/datum/job/terragov/command/assault_crewman = 2,
+		/datum/job/terragov/command/assault_crewman = 0,
 		/datum/job/terragov/command/transport_crewman = 1,
 		/datum/job/terragov/silicon/ai = 1,
 		/datum/job/terragov/squad/engineer = 1,

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -553,8 +553,8 @@ You can serve your Division in a variety of roles, so choose carefully."})
 
 /datum/job/terragov/command/assault_crewman/add_job_points(amount)
 	. = ..()
-	if(total_positions % 2)
-		add_job_positions(1) //always 2 there are, a master and an apprentice
+	if(total_positions == 1)
+		add_job_positions(2) //always 2 there are, a master and an apprentice
 
 /datum/job/terragov/command/assault_crewman/radio_help_message(mob/M)
 	. = ..()

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -537,7 +537,7 @@ You can serve your Division in a variety of roles, so choose carefully."})
 	exp_requirements = XP_REQ_UPPER_INTERMEDIATE
 	exp_type = EXP_TYPE_MARINES
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_ALWAYS_VISIBLE_ON_MINIMAP
-	job_points_needed = 80
+	job_points_needed = 60
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -537,7 +537,7 @@ You can serve your Division in a variety of roles, so choose carefully."})
 	exp_requirements = XP_REQ_UPPER_INTERMEDIATE
 	exp_type = EXP_TYPE_MARINES
 	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_ALWAYS_VISIBLE_ON_MINIMAP
-	job_points_needed = 999 //50
+	job_points_needed = 80
 	jobworth = list(
 		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,


### PR DESCRIPTION
## `Основные изменения`

Для танкиста теперь нужен хайпоп. Для АПЦ ничего не изменилось

## `Как это улучшит игру`

Слишком сильная хуйня против ксен для среднего онлайна на сервере в 50-60 человек, к тому же при хайпопе админы и так почти всегда будут открывать слоты на него.

## `Ченджлог`

Для танкиста нужно 60 поинтов.
```
:cl:
balance: Увеличил требования в количестве маров для роли танкиста
/:cl:
```
