### PR TITLE
Bullet feedback now properly checks for bullet damage.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -916,7 +916,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(stat != DEAD && proj.firer)
 		proj.firer.record_projectile_damage(damage, src)	//Tally up whoever the shooter was
 
-	if(damage)
+	if(damage > 0)
 		if(do_shrapnel_roll(proj, damage))
 			feedback_flags |= (BULLET_FEEDBACK_SHRAPNEL|BULLET_FEEDBACK_SCREAM)
 			embed_projectile_shrapnel(proj)


### PR DESCRIPTION
## `Основные изменения`
Теперь проверка идёт не только на то существует ли `damage`, а и на то выше ли он 0.
## `Как это улучшит игру`
Баф хода.

Что-то вроде этого:
https://www.youtube.com/watch?v=ebWgte2395M
## `Ченджлог`
```
:cl:
fix: Теперь нельзя получить шрапнель, если урон пули был ниже 1.
/:cl:
```
