### PR TITLE
Бафф подствольного гранатомета

### DIFF
--- a/code/modules/projectiles/guns/grenade_launchers.dm
+++ b/code/modules/projectiles/guns/grenade_launchers.dm
@@ -139,8 +139,8 @@ The Grenade Launchers
 	desc = "A weapon-mounted, reloadable, two-shot grenade launcher."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "grenade"
-	max_shells = 1 //codex
-	max_chamber_items = 0
+	max_shells = 2 //codex
+	max_chamber_items = 1
 	fire_delay = 1 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/underbarrel_grenadelauncher.ogg'
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
@@ -176,6 +176,11 @@ The Grenade Launchers
 		/obj/item/explosive/grenade/impact,
 		/obj/item/explosive/grenade/sticky,
 		/obj/item/explosive/grenade/flashbang/stun,
+		/obj/item/explosive/grenade/m15,
+		/obj/item/explosive/grenade/sticky/trailblazer,
+		/obj/item/explosive/grenade/sticky/trailblazer/phosphorus,
+		/obj/item/explosive/grenade/sticky/cloaker,
+		/obj/item/explosive/grenade/mirage,
 	)
 
 	wield_delay_mod = 0.2 SECONDS


### PR DESCRIPTION
## `Основные изменения`
Подствольный гранатомет вмещает 2 гранаты и теперь может использовать все доступные в игре гранаты

## `Как это улучшит игру`
Повышение играбельности модуля, фидбек игроков

## `Ченджлог`
```
:cl:
balance: Подствольный гранатомет вмещает 2 гранаты.
balance: Подствольный гранатомет теперь вмещает в себя м15 и трейлблейзеры.
/:cl:
```