### PR TITLE
Fixes wrong receiver type on Talos telecomms.

### DIFF
--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -21523,6 +21523,10 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/brig)
+"mMJ" = (
+/obj/machinery/telecomms/receiver/preset/right,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/command/telecomms)
 "mMT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -69473,7 +69477,7 @@ vfY
 vfY
 ver
 vfY
-msD
+mMJ
 xPw
 eRE
 snt

--- a/tools/UpdatePaths/scripts/telecomms.txt
+++ b/tools/UpdatePaths/scripts/telecomms.txt
@@ -11,7 +11,7 @@
 /obj/machinery/telecomms/bus/preset_four/cicbackup :  /obj/machinery/telecomms/bus/preset/four/cicbackup
 
 /obj/machinery/telecomms/receiver/preset_left : /obj/machinery/telecomms/receiver/preset/left
-/obj/machinery/telecomms/receiver/preset_right : /obj/machinery/telecomms/receiver/preset/left
+/obj/machinery/telecomms/receiver/preset_right : /obj/machinery/telecomms/receiver/preset/right
 /obj/machinery/telecomms/receiver/preset_right/cicbackup : /obj/machinery/telecomms/receiver/preset/left
 /obj/machinery/telecomms/receiver/preset_right/som : /obj/machinery/telecomms/receiver/preset/left
 


### PR DESCRIPTION
## `Основные изменения`
На Талосе теперь правильный ресивер телекомов, позволяющий общаться на общем канале связи.
## `Ченджлог`
```
:cl:
map: На Талосе теперь правильный ресивер телекомов, позволяющий общаться на общем канале связи.
/:cl:
```
