### PR TITLE
Fixes connected ammo magazines not unloading from the gun on vendor restock.

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -649,6 +649,7 @@
 			var/obj/item/storage/S = item_to_stock.loc
 			S.remove_from_storage(item_to_stock, user.loc, user)
 
+	item_to_stock.removed_from_inventory(user)
 	qdel(item_to_stock)
 
 	if(amount >= 0) //R negative means infinite item, no need to restock


### PR DESCRIPTION
## `Основные изменения`
Исправлено то что подключенные к оружию магазину, не сбрасывали подключение к оружию при возврате в вендор.
## `Ченджлог`
```
:cl:
fix: Исправлено то что подключенные к оружию магазину, не сбрасывали подключение к оружию при возврате в вендор.
/:cl:
```
