### PR TITLE
Fixes turned on lanterns, having turned off sprite.

### DIFF
--- a/code/game/objects/items/flashlight.dm
+++ b/code/game/objects/items/flashlight.dm
@@ -209,4 +209,5 @@
 	raillight_compatible = FALSE
 
 /obj/item/flashlight/lantern/turned_on
+	icon_state = "lantern-on"
 	light_on = TRUE


### PR DESCRIPTION
## `Основные изменения`
Исправил то что включенные лампы, в саду Талоса, выглядели как выключенные.
## `Ченджлог`
```
:cl:
fix: Исправил то что включенные лампы, в саду Талоса, выглядели как выключенные.
/:cl:
```
