### PR TITLE
jetpackWithoutStagger

### DIFF
--- a/code/game/objects/items/jetpack.dm
+++ b/code/game/objects/items/jetpack.dm
@@ -172,6 +172,7 @@
 	desc = "Briefly fly using your jetpack."
 	keybind_flags = ABILITY_USE_STAGGERED|ABILITY_USE_BUSY
 	keybinding_signals = list(KEYBINDING_NORMAL = COMSIG_ITEM_TOGGLE_JETPACK)
+	use_state_flags = ABILITY_USE_STAGGERED
 
 /datum/action/ability/activable/item_toggle/jetpack/New(Target, obj/item/holder)
 	. = ..()


### PR DESCRIPTION
## `Основные изменения`
Бафф и так редкоиспользуемого джетпака
Джетпак можно применять находясь в стаггере. Честно похоже на баг
## `Как это улучшит игру`
Теперь марин может использовать джетпак несмотря на боль. Нелогично что мар спокойно стоя на ногах не мог его использовать и избегать особо критичных ситуаций для которых джетпак и был создан.
## `Ченджлог`
```
:cl:
balance: Джетпаку убрана проверка на стаггер
/:cl:
```