### PR TITLE
Handheld Charger and MRE for Cargo.

### DIFF
--- a/code/modules/reqs/engineering.dm
+++ b/code/modules/reqs/engineering.dm
@@ -43,6 +43,11 @@
 	contains = list(/obj/item/stack/sheet/mineral/junk/large_stack)
 	cost = 300
 
+/datum/supply_packs/engineering/handheld_charger
+	name = "handheld charger"
+	contains = list(/obj/item/tool/handheld_charger)
+	cost = 80
+
 /datum/supply_packs/engineering/plasmacutter
 	name = "plasma cutter"
 	contains = list(/obj/item/tool/pickaxe/plasmacutter/)

--- a/code/modules/reqs/supplies.dm
+++ b/code/modules/reqs/supplies.dm
@@ -8,6 +8,23 @@
 	containertype = /obj/structure/closet/crate/operations
 	cost = 40
 
+/datum/supply_packs/supplies/provision
+	name = "Emergency Provision Crate"
+	notes = "Contains 10 special TGMC MRE racions."
+	contains = list(/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE,
+	/obj/item/storage/box/MRE
+	)
+	containertype = /obj/structure/closet/crate/operations
+	cost = 65
+
 /datum/supply_packs/supplies/janitor
 	name = "assorted janitorial supplies"
 	contains = list(

--- a/code/modules/reqs/supplies.dm
+++ b/code/modules/reqs/supplies.dm
@@ -11,16 +11,17 @@
 /datum/supply_packs/supplies/provision
 	name = "Emergency Provision Crate"
 	notes = "Contains 10 special TGMC MRE racions."
-	contains = list(/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE,
-	/obj/item/storage/box/MRE
+	contains = list(
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
+		/obj/item/storage/box/MRE,
 	)
 	containertype = /obj/structure/closet/crate/operations
 	cost = 65


### PR DESCRIPTION
## `Основные изменения`

Добавляет ручной зарядник для батареек за 80 пойнтов, и ящик с МРЕ за 65 пойнтов в карго.

## `Как это улучшит игру`

Инженерный ручной зарядник давно напрашивался, учитывая, что весь медицинский стафф включая улучшенные дефибы и т.д. можно купить в карго. Коробка с МРЕ даст возможность марам с радиопаком раскошелится на личные пойнты, чтобы покушать, ну и отряд покормить. Идеально для антисоциальных морпехов, или в случае отсутствия шипсайда в карго.

## `Ченджлог`
```
:cl:
add: Добавил handheld charger в инженерный раздел карго за 85 пойнтов.
add: Добавил Emergency Provision Crate (EPC) с 10 МРЕ внутри в раздел снабжения карго за 65 пойнтов.
/:cl:
```
