### PR TITLE
Defender hard armor now only applies while fortified.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -241,6 +241,8 @@
 	X.crest_defense = on
 	X.update_icons()
 
+#define DEFENDER_FORTIFY_BULLET_HARD_ARMOR 10
+
 // ***************************************
 // *********** Fortify
 // ***************************************
@@ -265,11 +267,13 @@
 	if(X.fortify)
 		X.soft_armor = X.soft_armor.modifyAllRatings(-last_fortify_bonus)
 		X.soft_armor = X.soft_armor.modifyRating(BOMB = -last_fortify_bonus)
+		X.hard_armor = X.hard_armor.modifyRating(BULLET = -DEFENDER_FORTIFY_BULLET_HARD_ARMOR)
 
 		last_fortify_bonus = X.xeno_caste.fortify_armor
 
 		X.soft_armor = X.soft_armor.modifyAllRatings(last_fortify_bonus)
 		X.soft_armor = X.soft_armor.modifyRating(BOMB = last_fortify_bonus)
+		X.hard_armor = X.hard_armor.modifyRating(BULLET = DEFENDER_FORTIFY_BULLET_HARD_ARMOR)
 	else
 		last_fortify_bonus = X.xeno_caste.fortify_armor
 
@@ -314,12 +318,14 @@
 			to_chat(X, span_xenowarning("We tuck ourselves into a defensive stance."))
 		X.soft_armor = X.soft_armor.modifyAllRatings(last_fortify_bonus)
 		X.soft_armor = X.soft_armor.modifyRating(BOMB = last_fortify_bonus) //double bomb bonus for explosion immunity
+		X.hard_armor = X.hard_armor.modifyRating(BULLET = DEFENDER_FORTIFY_BULLET_HARD_ARMOR)
 		owner.drop_all_held_items() // drop items (hugger/jelly)
 	else
 		if(!silent)
 			to_chat(X, span_xenowarning("We resume our normal stance."))
 		X.soft_armor = X.soft_armor.modifyAllRatings(-last_fortify_bonus)
 		X.soft_armor = X.soft_armor.modifyRating(BOMB = -last_fortify_bonus)
+		X.hard_armor = X.hard_armor.modifyRating(BULLET = -DEFENDER_FORTIFY_BULLET_HARD_ARMOR)
 		REMOVE_TRAIT(X, TRAIT_IMMOBILE, FORTIFY_TRAIT)
 		REMOVE_TRAIT(X, TRAIT_STOPS_TANK_COLLISION, FORTIFY_TRAIT)
 
@@ -464,3 +470,5 @@
 		deltimer(spin_loop_timer)
 		spin_loop_timer = null
 	UnregisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_FLOORED), SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED), SIGNAL_ADDTRAIT(TRAIT_IMMOBILE)))
+
+#undef DEFENDER_FORTIFY_BULLET_HARD_ARMOR

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -33,7 +33,6 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 40, BULLET = 45, LASER = 45, ENERGY = 40, BOMB = 20, BIO = 30, FIRE = 10, ACID = 30)
-	hard_armor = list(MELEE = 0, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Minimap Icon *** //
 	minimap_icon = "defender"


### PR DESCRIPTION
## `Основные изменения`
Убрал общую хард броню дефендера, перенес её в фортифай.
## `Как это улучшит игру`
То что т1 каста, пусть и рассчитанная на то что она танк, живучее большинства т3 является откровенным кринжом.
Аргументация по-типу проблем с выходом из стойки - является полным скилл ишшуем, попробуй там, ну не знаю, не садиться посреди унгаболла, и пытаться уйти на 10% процентах хп.
## `Ченджлог`
```
:cl:
balance: Убрал общую хард броню дефендера, перенес её в фортифай.
/:cl:
```
