### PR TITLE
Fixes carrier hugger overlays not applying correctly.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -9,8 +9,6 @@
 	health = 200
 	maxHealth = 200
 	plasma_stored = 50
-	///Number of huggers the carrier is currently carrying
-	var/huggers = 0
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_NORMAL
 	pixel_x = -16 //Needed for 2x2
@@ -18,6 +16,8 @@
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)
+	///Number of huggers the carrier is currently carrying
+	var/huggers = 0
 	///Facehuggers overlay
 	var/mutable_appearance/hugger_overlays_icon
 	///The number of huggers the carrier reserves against observer possession.
@@ -28,7 +28,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/carrier/Initialize(mapload)
 	. = ..()
-	hugger_overlays_icon = mutable_appearance('icons/Xeno/castes/carrier/effects.dmi',"empty")
+	hugger_overlays_icon = mutable_appearance(effects_icon, "empty")
 
 /mob/living/carbon/xenomorph/carrier/get_status_tab_items()
 	. = ..()
@@ -47,19 +47,17 @@
 		return
 
 	///Dispayed number of huggers
-	var/displayed = round(( huggers / xeno_caste.huggers_max ) * 3.999) + 1
-
+	var/displayed = round((huggers / xeno_caste.huggers_max) * 3.999) + 1
 	for(var/i = 1; i <= displayed; i++)
 		if(stat == DEAD)
-			hugger_overlays_icon.overlays += mutable_appearance(icon, "clinger_[i] Knocked Down")
+			hugger_overlays_icon.overlays += mutable_appearance(effects_icon, "clinger_[i] Knocked Down")
 		else if(lying_angle)
 			if((resting || IsSleeping()) && (!IsParalyzed() && !IsUnconscious() && health > 0))
-				hugger_overlays_icon.overlays += mutable_appearance(icon, "clinger_[i] Sleeping")
+				hugger_overlays_icon.overlays += mutable_appearance(effects_icon, "clinger_[i] Sleeping")
 			else
-				hugger_overlays_icon.overlays +=mutable_appearance(icon, "clinger_[i] Knocked Down")
+				hugger_overlays_icon.overlays += mutable_appearance(effects_icon, "clinger_[i] Knocked Down")
 		else
-			hugger_overlays_icon.overlays +=mutable_appearance(icon, "clinger_[i]")
-
+			hugger_overlays_icon.overlays += mutable_appearance(effects_icon, "clinger_[i]")
 	overlays += hugger_overlays_icon
 
 //Observers can become playable facehuggers by clicking on the carrier


### PR DESCRIPTION
## `Основные изменения`
Хаггер оверлей на Керриере теперь опять работает.
## `Ченджлог`
```
:cl:
fix: Хаггер оверлей на Керриере теперь опять работает.
/:cl:
```
