### PR TITLE
Фикс отсутствия паверфиста на дистрессе

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -88,6 +88,7 @@
 			/obj/item/storage/holster/blade/harvester/full = -1,
 			/obj/item/weapon/twohanded/spear/tactical = -1,
 			/obj/item/weapon/twohanded/spear/tactical/harvester = -1,
+			/obj/item/weapon/powerfist = -1,
 			/obj/item/weapon/twohanded/glaive/harvester = -1,
 			/obj/item/weapon/shield/riot/marine = 6,
 			/obj/item/weapon/shield/riot/marine/deployable = 6,


### PR DESCRIPTION
## `Основные изменения`
Фикс

## `Как это улучшит игру`
Фикс

## `Ченджлог`
```
:cl:
fix: Паверфист теперь есть в оружейном вендоре на дистрессе
/:cl:
```
