### PR TITLE
Mimir great again

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -181,7 +181,7 @@
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 10)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0.2
 	slot = ATTACHMENT_SLOT_MODULE
 	///siemens coefficient mod for gas protection.
@@ -208,7 +208,7 @@
 	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 5)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 	slowdown = 0.3
 
 //SOM version
@@ -226,14 +226,14 @@
 	icon_state = "mimir_head"
 	item_state = "mimir_head_a"
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "mimir_head_xn")
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 10)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
 	name = "Mark 1 Mimir Environmental Helmet System"
 	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks. Pairing this with a Mimir suit module and mask will make the user impervious to xeno gas clouds."
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 5)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 
 //Explosive defense armor
 /obj/item/armor_module/module/hlin_explosive_armor

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 120
+	cost = 200
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 200
+	cost = 160
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 160
+	cost = 220
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"


### PR DESCRIPTION
## `Основные изменения`
Увеличил защиту от кислоты и незначительно уменьшил защиту от мили у обеих версий мимира, поднял цену в карго до 220 поинтов.
## `Как это улучшит игру`
Морпехи в тяже + мимир 2 не будут отлетать за 6 плевков спиттера/претора. Мимир 2 (и, возможно, в связке с тяжёлой бронёй) теперь есть смысл брать против О БОЖЕ кислоты ксеносов, а не только от колодцев. Рендж касты всё ещё смогут задушить кислотой мимирщика, но на это потребуется чуть больше времени. Затариться всем взводом мимирами в начале раунда не выйдет (наверное?) из-за повышенной цены.

Меньше бесполезных модулей в карго.
## `Ченджлог`
```
:cl:
balance: Защита мимира 1 от кислоты 5 -> 10, мили 0 -> -5.
Защита мимира 2 от кислоты 10 -> 25, мили 0 -> -5.
Цена мимира 2 120 -> 220.
/:cl:
```
