### PR TITLE
Mimir great again V2

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -181,7 +181,7 @@
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 10)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0.2
 	slot = ATTACHMENT_SLOT_MODULE
 	///siemens coefficient mod for gas protection.
@@ -208,7 +208,7 @@
 	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 5)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 	slowdown = 0.3
 
 //SOM version
@@ -226,14 +226,14 @@
 	icon_state = "mimir_head"
 	item_state = "mimir_head_a"
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "mimir_head_xn")
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 10)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
 	name = "Mark 1 Mimir Environmental Helmet System"
 	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks. Pairing this with a Mimir suit module and mask will make the user impervious to xeno gas clouds."
-	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 5)
+	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 
 //Explosive defense armor
 /obj/item/armor_module/module/hlin_explosive_armor

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -210,7 +210,6 @@
 	item_state = "mod_biohazard_a"
 	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 	slowdown = 0.3
-	siemens_coefficient_mod = -0.9
 	permeability_coefficient_mod = -0.5
 	gas_transfer_coefficient_mod = -0.5
 

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -177,14 +177,14 @@
 */
 /obj/item/armor_module/module/mimir_environment_protection
 	name = "\improper Mark 2 Mimir Environmental Resistance System"
-	desc = "Designed for mounting on modular armor. This newer model provides great resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
+	desc = "Designed for mounting on modular armor. This newer model provides great resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to any gas clouds. Will impact mobility."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0.2
 	slot = ATTACHMENT_SLOT_MODULE
-	///siemens coefficient mod for gas protection.
+	///siemens (electro resist) coefficient mod for gas protection.
 	var/siemens_coefficient_mod = -0.9
 	///permeability coefficient mod for gas protection.
 	var/permeability_coefficient_mod = -1
@@ -205,11 +205,14 @@
 
 /obj/item/armor_module/module/mimir_environment_protection/mark1
 	name = "\improper Mark 1 Mimir Environmental Resistance System"
-	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user impervious to xeno gas clouds. Will impact mobility."
+	desc = "Designed for mounting on modular armor. This older model provides minor resistance to acid, biological, and radiological attacks. Pairing this with a Mimir helmet module and mask will make the user almost impervious to any gas clouds. Will impact mobility."
 	icon_state = "mod_biohazard"
 	item_state = "mod_biohazard_a"
-	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 	slowdown = 0.3
+	siemens_coefficient_mod = -0.9
+	permeability_coefficient_mod = -0.5
+	gas_transfer_coefficient_mod = -0.5
 
 //SOM version
 /obj/item/armor_module/module/mimir_environment_protection/som
@@ -220,20 +223,20 @@
 	//soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 0, ACID = 20)
 
 /obj/item/armor_module/module/mimir_environment_protection/mimir_helmet
-	name = "Mimir Environmental Helmet System"
-	desc = "Designed for mounting on a modular helmet. Provides good resistance to xeno gas clouds"
+	name = "Mark 2 Mimir Environmental Helmet System"
+	desc = "Designed for mounting on a modular helmet. Provides good resistance to xeno gas clouds."
 	icon = 'icons/mob/modular/modular_armor_modules.dmi'
 	icon_state = "mimir_head"
 	item_state = "mimir_head_a"
 	variants_by_parent_type = list(/obj/item/clothing/head/modular/m10x = "mimir_head_xn")
-	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 25)
 	slowdown = 0
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 
-/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1 //gas protection
+/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet/mark1
 	name = "Mark 1 Mimir Environmental Helmet System"
-	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks. Pairing this with a Mimir suit module and mask will make the user impervious to xeno gas clouds."
-	soft_armor = list(MELEE = -5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
+	desc = "Designed for mounting on a modular helmet. This older model provides minor resistance to acid and biological attacks."
+	soft_armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 5, FIRE = 0, ACID = 10)
 
 //Explosive defense armor
 /obj/item/armor_module/module/hlin_explosive_armor

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 120
+	cost = 160
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 120
+	cost = 200
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 160
+	cost = 120
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 220
+	cost = 160
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 200
+	cost = 160
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/reqs/armor.dm
+++ b/code/modules/reqs/armor.dm
@@ -86,7 +86,7 @@
 		/obj/item/armor_module/module/mimir_environment_protection/mimir_helmet,
 		/obj/item/armor_module/module/mimir_environment_protection,
 	)
-	cost = 160
+	cost = 220
 
 /datum/supply_packs/armor/modular/attachments/artemis_mark_two
 	name = "Freyr Mark 2 helmet module"

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -186,9 +186,10 @@
 		charges_used ++
 
 	if(!isxeno(stepper))
+		var/mob/living/carbon/human/H = stepper
 		stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
-		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33)
-		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33)
+		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33 - 20 * H.get_permeability_protection()) //Wearing mimir MK1/2 will soften damage from wells by reducing AP
+		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33 - 20 * H.get_permeability_protection()) //without providing full protection against them
 		stepper.visible_message(span_danger("[stepper] is immersed in [src]'s acid!") , \
 		span_danger("We are immersed in [src]'s acid!") , null, 5)
 		playsound(stepper, "sound/bullets/acid_impact1.ogg", 10 * charges)


### PR DESCRIPTION
## `Основные изменения`
Увеличил защиту от кислоты у обеих версий мимимирки, у МК1 урезал защиту от газов, уменьшил урон от попадания в колодцы при частичном/полном комплекте мимира и шлема, поднял цену МК2 в карго до 160 поинтов.
## `Как это улучшит игру`
Морпехи в МК2 и МК1 будут отлетать от плевков дольше (в МК2 в почти два раза дольше). Теперь урон (вернее АП) колодцев дополнительно режется в зависимости от надетого шлема + версии мимира. МК2 позволяет ходить в кислотных облаках и прочих дымах без стыда и совести (возможно надо нерфить), МК1 же справляется в два раза хуже и будет пропускать урон от кислотных облаков и пропускать в тело газы (до этого у МК1 был такой же полный игнор всех газов как у МК2).
Цена была поднята исходя из простой логики: тюр даёт небольшое повышение выживаемости (+5/+10) против самого частого урона, мимир же почти закрывает вопрос с рендж кастами, газами и так ненавистными колодцами.

Меньше бесполезных модулей в карго.
## `Ченджлог`
```
:cl:
balance: Защита мимира 1 от кислоты 5 -> 10, защита от газов снижена в два раза.
balance: Защита мимира 2 от кислоты 10 -> 25.
balance: Снижение урона от колодцев в зависимости от надетого шлема с мимиром + версии мимира.
balance: Ценам мимира 2 в карго 120 -> 160.
/:cl:
```
