### PR TITLE
SG-85 goes BRRR

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -108,6 +108,14 @@
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
-	damage = 25
-	penetration = -15
+	damage = 10
+	penetration = 20
 	damage_falloff = 0.1
+	var/shatter_duration = 3 SECONDS
+
+/datum/ammo/bullet/smart_minigun/on_hit_mob(mob/M, obj/projectile/proj)
+	if(!isliving(M))
+		return
+
+	var/mob/living/living_victim = M
+	living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, shatter_duration)

--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -109,7 +109,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
 	damage = 10
-	penetration = 15
+	penetration = 20
 	damage_falloff = 0.1
 	var/shatter_duration = 3 SECONDS
 

--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -109,7 +109,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
 	damage = 10
-	penetration = 20
+	penetration = 25
 	damage_falloff = 0.1
 	var/shatter_duration = 3 SECONDS
 

--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -109,7 +109,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
 	damage = 10
-	penetration = 20
+	penetration = 15
 	damage_falloff = 0.1
 	var/shatter_duration = 3 SECONDS
 

--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -109,7 +109,7 @@
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
 	damage = 10
-	penetration = 25
+	penetration = 20
 	damage_falloff = 0.1
 	var/shatter_duration = 3 SECONDS
 

--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -108,7 +108,7 @@
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range = 12
-	damage = 10
+	damage = 12
 	penetration = 20
 	damage_falloff = 0.1
 	var/shatter_duration = 3 SECONDS

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -431,8 +431,8 @@
 	icon_state = "powerpacksg"
 	flags_magazine = MAGAZINE_WORN|MAGAZINE_REFILLABLE
 	default_ammo = /datum/ammo/bullet/smart_minigun
-	current_rounds = 2000
-	max_rounds = 2000
+	current_rounds = 1000
+	max_rounds = 1000
 	caliber = CALIBER_10x26_CASELESS
 	flags_item_map_variant = null
 


### PR DESCRIPTION
## `Основные изменения`
Вернул статы СГ-85 до его баффа (нерфа) Татаром, добавил шаттер на 3 секунды.
## `Как это улучшит игру`
Вилка для стен станет миниганом, способным любой касте нанести урон, как и полагается СГ, и снизить защиту для челиков с ХП патронами (такие существуют?). Брать слот СГшера ради сноса стен и убийства 6 ксеносов из каст Т1-Т2, когда абсолютно любой негр ходит под ферами защиты кинга/квины + апгрейдами и минусовым 20 АП у пушки - вышка парада кринжа. Для этих целей есть ХП патроны у бесплатных пукалок.
Да - с этой пушкой ты не пойдёшь беззаботно рашить застрой в сравнении с Т25 (абалдеть, а чё другой геймплей существует?), но, стреляя из-за спин союзников, заливая всё пространство пулями и прикрывая тыл, можно принести не меньший импакт, тем более со снижением брони на 20% на 3 секунды с выстрела.
## `Ченджлог`
```
:cl:
balance: Добавил шаттер (минус 20% брони) на 3 секунды.
balance: Урон 25 -> 12, АП -15 -> 20.
balance: Снижено кол-во патронов в паверпаке с 2000 до 1000.
/:cl:
```
