### PR TITLE
T1 Crusher (Sent)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -66,6 +66,7 @@
 	particle_holder = new(owner, /particles/toxic_slash)
 	particle_holder.pixel_x = 9
 	particle_holder.pixel_y = 2
+	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyRating(bullet = 60)
 	succeed_activate()
 	add_cooldown()
 
@@ -97,6 +98,7 @@
 	xeno_owner.balloon_alert(xeno_owner, "Toxic Slash over") //Let the user know
 	xeno_owner.playsound_local(xeno_owner, 'sound/voice/alien/hiss8.ogg', 25)
 	action_icon_state = "neuroclaws_off"
+	xeno_owner.soft_armor = xeno_owner.soft_armor.modifyRating(bullet = -60)
 
 /datum/action/ability/xeno_action/toxic_slash/on_cooldown_finish()
 	owner.playsound_local(owner, 'sound/effects/alien/newlarva.ogg', 25, 0, 1)


### PR DESCRIPTION
## `Основные изменения`

Во время действия своих токсик ударов, (где-то 4.5 секунды) сент получает +60 буллет армора.

## `Как это улучшит игру`

Сент сможет во время основной фазы боя (когда даёт свой прокаст) не умерать за один зажим. Возможно на нём снова можно будет играть

## `Мем отдел`
ИДЕЯ НЕ МОЯ, ВСЕ ДОЁБЫ К МЫКОЛЕ
![image](https://github.com/user-attachments/assets/719322f9-c666-41fd-b378-38b7fae146c0)

## `Ченджлог`
```
:cl:
add: Сентинель теперь получает +60 буллет армора на время активации своих токсичных ударов.
/:cl:
```
