### PR TITLE
слабое ускорение работы со шрапой для тех кто не имеют скилл на его доставание

### DIFF
--- a/code/game/objects/items/devices/tweezers.dm
+++ b/code/game/objects/items/devices/tweezers.dm
@@ -22,4 +22,4 @@
 
 /obj/item/tweezers_advanced/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/shrapnel_removal, 1 SECONDS, 12 SECONDS)
+	AddElement(/datum/element/shrapnel_removal, 1 SECONDS, SKILL_TASK_AVERAGE)

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -391,7 +391,7 @@
 /obj/item/weapon/combat_knife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)
-	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, 12 SECONDS, 10)
+	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, 2 SECONDS, 10)
 
 /obj/item/weapon/combat_knife/upp
 	name = "\improper Type 30 survival knife"

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -391,7 +391,7 @@
 /obj/item/weapon/combat_knife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)
-	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, 2 SECONDS, 10)
+	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE 50, 10)
 
 /obj/item/weapon/combat_knife/upp
 	name = "\improper Type 30 survival knife"

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -391,7 +391,7 @@
 /obj/item/weapon/combat_knife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)
-	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE 50, 10)
+	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE, 10)
 
 /obj/item/weapon/combat_knife/upp
 	name = "\improper Type 30 survival knife"

--- a/code/modules/projectiles/attachables/muzzle.dm
+++ b/code/modules/projectiles/attachables/muzzle.dm
@@ -85,7 +85,7 @@
 /obj/item/attachable/bayonetknife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)
-	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, 12 SECONDS, 10)
+	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE 50, 10)
 
 /obj/item/attachable/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)

--- a/code/modules/projectiles/attachables/muzzle.dm
+++ b/code/modules/projectiles/attachables/muzzle.dm
@@ -85,7 +85,7 @@
 /obj/item/attachable/bayonetknife/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/scalping)
-	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE 50, 10)
+	AddElement(/datum/element/shrapnel_removal, 12 SECONDS, SKILL_TASK_AVERAGE, 10)
 
 /obj/item/attachable/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	if(target == user && !user.do_self_harm)


### PR DESCRIPTION
## `Основные изменения`
12 секунд умноженные на плохой скилл заменены на дефайн SKILL_TASK_AVERAGE
## `Как это улучшит игру`
Чуточку быстрее мары изучают себя прежде чем начать доставать шрапу
## `Ченджлог`
```
:cl:
balance: Фамбл при доставании шрапнели ножом, был уменьшен с 12 секунд умноженных на недостаток скилла до 5 умноженных на недостаток скилла.
/:cl:
```