### PR TITLE
Нерф флаеров

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -517,8 +517,8 @@
 	light_color = LIGHT_COLOR_FLARE
 	G_throw_sound = null
 	var/fuel = 0
-	var/lower_fuel_limit = 450
-	var/upper_fuel_limit = 750
+	var/lower_fuel_limit = 25
+	var/upper_fuel_limit = 30
 
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -517,8 +517,8 @@
 	light_color = LIGHT_COLOR_FLARE
 	G_throw_sound = null
 	var/fuel = 0
-	var/lower_fuel_limit = 25
-	var/upper_fuel_limit = 30
+	var/lower_fuel_limit = 60
+	var/upper_fuel_limit = 75
 
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2


### PR DESCRIPTION
## `Основные изменения`
Флаера теперь не горят о полчаса, а от 1.5 до 2 минут

## `Как это улучшит игру`
Теперь сложней засрать карту флаерами, которые горят половину раунда

## `Ченджлог`
```
:cl:
balance: Флаера теперь горят от 1.5 до 2 минут вместо 25-30 минут
/:cl:
```