### PR TITLE
Changes default jumping keybind from Space to V.

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -19,7 +19,7 @@
 	return TRUE
 
 /datum/keybinding/living/attempt_jump
-	hotkey_keys = list("Space")
+	hotkey_keys = list("V")
 	name = "Jump"
 	full_name = "Jump"
 	description = "Jumps, if your mob is capable of doing so."


### PR DESCRIPTION
## `Основные изменения`
Изменил дефолтный кейбинд для прыжка с пробела на V, так как они конфликтуют.
## `Как это улучшит игру`
Давно пора
## `Ченджлог`
```
:cl:
qol: Изменил дефолтный кейбинд для прыжка с пробела на V.
/:cl:
```
