### PR TITLE
Buffs sg29.

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/machinegun.dm
@@ -90,17 +90,6 @@
 	penetration = 10
 	sundering = 1
 
-/datum/ammo/bullet/sg29
-	name = "smartmachinegun bullet"
-	bullet_color = COLOR_SOFT_RED //Red bullets to indicate friendly fire restriction
-	hud_state = "smartgun"
-	hud_state_empty = "smartgun_empty"
-	flags_ammo_behavior = AMMO_BALLISTIC
-	accurate_range = 8
-	damage = 20
-	penetration = 5
-	additional_xeno_penetration = 20
-
 /datum/ammo/bullet/smart_minigun
 	name = "smartminigun bullet"
 	bullet_color = COLOR_SOFT_RED //Red bullets to indicate friendly fire restriction

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1342,7 +1342,8 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/sgstock, /obj/item/attachable/sgbarrel)
 	gun_skill_category = SKILL_SMARTGUN //Uses SG skill for the penalties.
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
-	fire_delay = 0.2 SECONDS
+
+	fire_delay = 0.15 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.1

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -309,7 +309,7 @@
 	icon_state = "sg29"
 	icon_state_mini = "mag_sg29"
 	w_class = WEIGHT_CLASS_NORMAL
-	default_ammo = /datum/ammo/bullet/sg29
+	default_ammo = /datum/ammo/bullet/rifle/t25
 	max_rounds = 250
 	reload_delay = 1.3 SECONDS
 


### PR DESCRIPTION
## `Основные изменения`
Сг29 теперь использует один патрон с Сг25, различий там только в цифрах пробития и точной дистанции стрельбы.
Точная дистанция стрельбы сг29 поднята с 8 до 20. Пробитие поднято с 25 до 45. Задержка между выстрелами уменьшена с 0.2 секунд до 0.15.
В стерильных условиях от сг29 варриор умирает за 4.5 секунд, от сг25 умирает за 6 секунд.
## `Как это улучшит игру`
Сг29 станет альтернативой сг25, а не просто неиспользуемой пушкой.
## `Ченджлог`
```
:cl:
balance: Точная дистанция стрельбы сг29 поднята с 8 до 20. Пробитие поднято с 25 до 45. Задержка между выстрелами уменьшена с 0.2 секунд до 0.15.
/:cl:
```
