### PR TITLE
Fixes boosty button theme. Some adjucements to interface buttons.

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -7,11 +7,10 @@
 		to_chat(src, span_warning("The wiki URL is not set in the server configuration."))
 		return
 
-	if(alert("This will open the wiki in your browser. Are you sure?", "Wiki", "Yes", "No") != "Yes")
+	if(tgui_alert(src, "This will open the wiki in your browser. Are you sure?", "Wiki", list("Yes", "No"), 0) != "Yes")
 		return
 
 	DIRECT_OUTPUT(src, link(CONFIG_GET(string/wikiurl)))
-
 
 /client/verb/boosty()
 	set name = "boosty"
@@ -21,11 +20,10 @@
 		to_chat(src, span_warning("The donation URL is not set in the server configuration."))
 		return
 
-	if(alert("This will open the boosty in your browser. Are you sure?", "Forum", "Yes", "No") != "Yes")
+	if(tgui_alert(src, "This will open the boosty in your browser. Are you sure?", "Forum", list("Yes", "No"), 0) != "Yes")
 		return
 
 	DIRECT_OUTPUT(src, link(CONFIG_GET(string/donationurl)))
-
 
 /client/verb/rules()
 	set name = "rules"
@@ -35,11 +33,10 @@
 		to_chat(src, span_warning("The rules URL is not set in the server configuration."))
 		return
 
-	if(alert("This will open the rules in your browser. Are you sure?", "Rules", "Yes", "No") != "Yes")
+	if(tgui_alert("This will open the rules in your browser. Are you sure?", "Rules", list("Yes", "No"), 0) != "Yes")
 		return
 
 	DIRECT_OUTPUT(src, link(CONFIG_GET(string/rulesurl)))
-
 
 /client/verb/discord()
 	set name = "discord"
@@ -49,11 +46,10 @@
 		to_chat(src, span_warning("The Discord URL is not set in the server configuration."))
 		return
 
-	if(alert("This will open our Discord in your browser. Are you sure?", "Discord", "Yes", "No") != "Yes")
+	if(tgui_alert(src, "This will open our Discord in your browser. Are you sure?", "Discord", list("Yes", "No"), 0) != "Yes")
 		return
 
 	DIRECT_OUTPUT(src, link(CONFIG_GET(string/discordurl)))
-
 
 /client/verb/github()
 	set name = "github"
@@ -63,11 +59,10 @@
 		to_chat(src, span_warning("The bug tracker URL is not set in the server configuration."))
 		return
 
-	if(alert("This will open our bug tracker page in your browser. Are you sure?", "Github", "Yes", "No") != "Yes")
+	if(tgui_alert(src, "This will open our bug tracker page in your browser. Are you sure?", "Github", list("Yes", "No"), 0) != "Yes")
 		return
 
 	DIRECT_OUTPUT(src, link(CONFIG_GET(string/githuburl)))
-
 
 /client/verb/webmap()
 	set name = "webmap"
@@ -79,7 +74,7 @@
 		return
 	var/map_url
 
-	var/choice = alert("Do you want to view the ground or the ship?",,"Ship","Ground","Cancel")
+	var/choice = tgui_alert(src, "Do you want to view the ground or the ship?", "Webmap", list("Ship", "Ground"), 0)
 	switch(choice)
 		if("Ship")
 			map_url = SSmapping.configs[SHIP_MAP].map_file

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -154,8 +154,8 @@ window "infowindow"
 		is-vert = false
 	elem "changelog"
 		type = BUTTON
-		pos = 6,5
-		size = 94x20
+		pos = 0,5
+		size = 90x20
 		anchor1 = 1,0
 		anchor2 = 16,0
 		saved-params = "is-checked"
@@ -163,7 +163,7 @@ window "infowindow"
 		command = "changelog"
 	elem "discord"
 		type = BUTTON
-		pos = 100,5
+		pos = 90,5
 		size = 90x20
 		anchor1 = 16,0
 		anchor2 = 30,0
@@ -172,7 +172,7 @@ window "infowindow"
 		command = "discord"
 	elem "rules"
 		type = BUTTON
-		pos = 190,5
+		pos = 180,5
 		size = 90x20
 		anchor1 = 30,0
 		anchor2 = 44,0
@@ -181,7 +181,7 @@ window "infowindow"
 		command = "rules"
 	elem "wiki"
 		type = BUTTON
-		pos = 280,5
+		pos = 270,5
 		size = 90x20
 		anchor1 = 44,0
 		anchor2 = 58,0
@@ -190,7 +190,7 @@ window "infowindow"
 		command = "wiki"
 	elem "boosty"
 		type = BUTTON
-		pos = 370,5
+		pos = 360,5
 		size = 90x20
 		anchor1 = 58,0
 		anchor2 = 72,0
@@ -199,7 +199,7 @@ window "infowindow"
 		command = "boosty"
 	elem "github"
 		type = BUTTON
-		pos = 460,5
+		pos = 450,5
 		size = 90x20
 		anchor1 = 72,0
 		anchor2 = 86,0
@@ -208,14 +208,13 @@ window "infowindow"
 		command = "github"
 	elem "webmap"
 		type = BUTTON
-		pos = 550,5
-		size = 90x20
+		pos = 540,5
+		size = 95x20
 		anchor1 = 86,0
 		anchor2 = 100,0
 		saved-params = "is-checked"
 		text = "Webmap"
 		command = "webmap"
-
 
 window "outputwindow"
 	elem "outputwindow"

--- a/tgui/packages/tgui-panel/themes.ts
+++ b/tgui/packages/tgui-panel/themes.ts
@@ -59,6 +59,8 @@ export const setClientTheme = (name) => {
       'github.text-color': '#000000',
       'webmap.background-color': 'none',
       'webmap.text-color': '#000000',
+      'boosty.background-color': 'none',
+      'boosty.text-color': '#000000',
       // Status and verb tabs
       'output.background-color': 'none',
       'output.text-color': '#000000',
@@ -113,6 +115,8 @@ export const setClientTheme = (name) => {
       'github.text-color': COLOR_DARK_TEXT,
       'webmap.background-color': '#494949',
       'webmap.text-color': COLOR_DARK_TEXT,
+      'boosty.background-color': '#494949',
+      'boosty.text-color': COLOR_DARK_TEXT,
       // Status and verb tabs
       'output.background-color': COLOR_DARK_BG_DARKER,
       'output.text-color': COLOR_DARK_TEXT,


### PR DESCRIPTION
## `Основные изменения`
Перевел запросы от кнопок в тгуи.
Чуть сместил чтобы последняя кнопка не пропадала за экраном, и не было много свободного пространства.
Исправил то что у кнопки для бусти не было своей темы, из-за чего она всегда была белой.

![image](https://github.com/user-attachments/assets/feb84858-21dc-42b0-9e30-7859eef5554d)
## `Как это улучшит игру`
Чуть красивее.
## `Ченджлог`
```
:cl:
fix: Интерфейс кнопка для бусты теперь не выбивается из общей темы остальных кнопок.
/:cl:
```
