### PR TITLE
Fixes jump to area verb.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -682,7 +682,6 @@
 
 	var/mob/M = usr
 	var/chosen = tgui_input_list(usr, "Please, select an area.", "Select an area.", GLOB.sorted_areas, timeout = 0)
-	chosen = pick(get_area_turfs(chosen))
 	var/turf/T = pick(get_area_turfs(chosen))
 	M.forceMove(T)
 


### PR DESCRIPTION
## `Основные изменения`
Исправил то что "Jump To Area" не работал.
## `Ченджлог`
```
:cl:
fix: Исправил то что "Jump To Area" не работал.
/:cl:
```
