### PR TITLE
Deletes free cargo ammunition from cargo vendor's "Surplus Special Equipment" tab

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -789,11 +789,6 @@
 		"Surplus Special Equipment" = list(
 			/obj/item/pinpointer = 1,
 			/obj/item/beacon/supply_beacon = 1,
-			/obj/item/ammo_magazine/rifle/sr81 = 3,
-			/obj/item/ammo_magazine/rifle/tx8 = 3,
-			/obj/item/ammo_magazine/rocket/sadar = 3,
-			/obj/item/ammo_magazine/minigun_powerpack = 2,
-			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/explosive/plastique = 5,
 			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/boomvest = 20,


### PR DESCRIPTION
## `Основные изменения`
Удалил бесплатные карго боеприпасы из карго вендора во вкладке "Surplus Special Equipment" (шахидок)
![image](https://github.com/user-attachments/assets/62e27db5-0822-42d4-96ed-31dfc96c4459)
## `Как это улучшит игру`
Непонятно зачем и почему, в карго вендоре вот просто есть халявные боеприпасы.
## `Ченджлог`
```
:cl:
del: Удалил бесплатные карго боеприпасы из карго вендора во вкладке "Surplus Special Equipment" (шахидок)
/:cl:
```
