### PR TITLE
Новый лут в вендор маров за поинты

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -76,7 +76,6 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjecto", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
-	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
 	/obj/item/reagent_containers/glass/bottle/lemoline/doctor = list(CAT_MARINE, "Lemoline bottle", 23, "cyan"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 8, "blue"),

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -76,10 +76,16 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjecto", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
+	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
+	/obj/item/reagent_containers/glass/bottle/lemoline/doctor = list(CAT_MARINE, "Lemoline bottle", 23, "cyan"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 8, "blue"),
-	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "blue"),
-	/obj/item/storage/briefcase/standard_magnum = list(CAT_MARINE, "R-76 crate", 22, "blue"),
+	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "orange2"),
+	/obj/item/storage/briefcase/standard_magnum = list(CAT_MARINE, "R-76 crate", 22, "red"),
+	/obj/item/storage/backpack/marine/satchel/scout_cloak = list(CAT_MARINE, "M68 Thermal cloak", 20, "blue"),
+	/obj/item/armor_module/module/night_vision = list(CAT_MARINE, "BE-35 night vision kit", 20, "blue"),
+	/obj/item/clothing/glasses/night_vision = list(CAT_MARINE, "BE-47 night vision goggles", 30, "blue"),
+	/obj/item/cell/night_vision_battery = list(CAT_MARINE, "night vision battery", 5, "blue"),
 ))
 
 GLOBAL_LIST_INIT(robot_gear_listed_products, list(


### PR DESCRIPTION
## `Основные изменения`
1. Лемолин за 23 поинта
2. Скаут плащ за 20
3. Найтвижен очки за 20
4. Найтвижен модуль за 30
5. Батарейки для найтвиженов за 5
6. Немного подкорректировал категории у предметов

## `Как это улучшит игру`
Возможность поиграться в стелс-билдах
Лемолин даст ручки для любителей поварить химозное говно

## `Ченджлог`
```
:cl:
balance: В вендор за поинты добавлен лемолин, скаут плащ, найтвижен очки, модуль и батарейки к ним
spellcheck: Р-76 и магазин АР-21 теперь отображают корректную категорию в вендоре за поинты
/:cl:
```
