### PR TITLE
Повышение капа реагентов с фреером до 10 вместо 8

### DIFF
--- a/code/modules/organs/organs.dm
+++ b/code/modules/organs/organs.dm
@@ -50,7 +50,7 @@
 	///How many drugs we can take before they overwhelm us. Decreases with damage
 	var/current_medicine_cap = 5
 	///Additional medicine capacity given by the freyr module.
-	var/freyr_medicine_cap = 3
+	var/freyr_medicine_cap = 5
 	///Whether we were over cap the last time we checked.
 	var/old_overflow = FALSE
 	///Total medicines added since last tick


### PR DESCRIPTION
## `Основные изменения`
Кап реагентов без бедтрипа стал 10 вместо 8
## `Как это улучшит игру`
можно чуть больше запихнуть в себя химии имея модуль специально созданный чтобы предотвращать побочный эффект, ввиде Confuse, от ее количества
## `Ченджлог`
```
:cl:
balance: Кап реагентов с модулем Freyr изменен с 8 до 10
/:cl:
```