### PR TITLE
Hijack fix

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -697,10 +697,6 @@
 		if(!(X.hive.hive_flags & HIVE_CAN_HIJACK))
 			to_chat(X, span_warning("Нашему улью не хватает экстрасенсорных способностей, чтобы украсть птицу."))
 			return
-		var/list/living_player_list = SSticker.mode.count_humans_and_xenos(list(X.z), COUNT_IGNORE_ALIVE_SSD)
-		if(living_player_list[1] > living_player_list[2]) // if there are more marines than xenos, we are unable to hijack
-			to_chat(X, span_xenowarning("Еще осталась добыча, на которую можно поохотиться!"))
-			return
 		switch(M.mode)
 			if(SHUTTLE_RECHARGING)
 				to_chat(X, span_xenowarning("Птица все еще остывает..."))


### PR DESCRIPTION
## `Основные изменения`

Возвращает возможность угнать нормандию при любом количестве морпехов.

## `Как это улучшит игру`

Запрет угона - уёбищный фикс маровского скилл ишью, вместо того чтобы мары включали мозг и не допускали угон, проблема была решена при помощи кода. 
Кроме того заблаговременный угон привносил в раунды разнообразие и не вносил сильного дисбаланса между сторонами, причин для убирания возможности я не вижу.

## `Ченджлог`
```
:cl:
add: Угонять нормандию теперь можно при любом количестве морпехов.
/:cl:
```
