### PR TITLE
Boomvest buff x1.5

### DIFF
--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -59,7 +59,7 @@
 		message_admins("[activator] has detonated an explosive vest with no warcry at [ADMIN_VERBOSEJMP(target)]")
 		log_game("[activator] has detonated an explosive vest with no warcry at [AREACOORD(target)]")
 
-	cell_explosion(target, 415, 100)
+	cell_explosion(target, 415, 83)
 	flame_radius(5, target)
 
 	activator.ex_act(500)

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -59,7 +59,7 @@
 		message_admins("[activator] has detonated an explosive vest with no warcry at [ADMIN_VERBOSEJMP(target)]")
 		log_game("[activator] has detonated an explosive vest with no warcry at [AREACOORD(target)]")
 
-	cell_explosion(target, 275, 65)
+	cell_explosion(target, 415, 100)
 	flame_radius(5, target)
 
 	activator.ex_act(500)


### PR DESCRIPTION
## `Основные изменения`
Бафф шахидки.
## `Как это улучшит игру`

Теперь взорвав шахидку впритык к ксену, она его гарантированно гибнет, а не оставит 20% ХП и шанс выбежать из огня на траву. Шахидки станут полезнее, а БТР с клон под модулем новой метой (наверное).
## `Ченджлог`
```
:cl:
balance: Бафф урона взрыва шахидки на х1.5. Теперь гибает сентинеля.
/:cl:
```
