### PR TITLE
Decreseases fumbling time for shrapnel removal in 2 times.

### DIFF
--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -43,7 +43,9 @@
 	if(skill < SKILL_MEDICAL_PRACTICED)
 		user.visible_message(span_notice("[user] fumbles around with the [removaltool]."),
 		span_notice("You fumble around figuring out how to use [removaltool]."))
-		if(!do_after(user, fumble_duration * (SKILL_MEDICAL_PRACTICED - skill), NONE, target, BUSY_ICON_UNSKILLED))
+		if(skill > SKILL_MEDICAL_UNTRAINED)
+			fumble_duration * 0.5 // let's not fuck around with absurd formulas
+		if(!do_after(user, fumble_duration, NONE, target, BUSY_ICON_UNSKILLED))
 			return
 	user.visible_message(span_green("[user] starts searching for shrapnel in [target] with the [removaltool]."), span_green("You start searching for shrapnel in [target] with the [removaltool]."))
 	if(!do_after(user, do_after_time, NONE, target, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))

--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -43,9 +43,7 @@
 	if(skill < SKILL_MEDICAL_PRACTICED)
 		user.visible_message(span_notice("[user] fumbles around with the [removaltool]."),
 		span_notice("You fumble around figuring out how to use [removaltool]."))
-		if(skill > SKILL_MEDICAL_UNTRAINED)
-			fumble_duration * 0.5 // let's not fuck around with absurd formulas
-		if(!do_after(user, fumble_duration, NONE, target, BUSY_ICON_UNSKILLED))
+		if(!do_after(user, fumble_duration - (fumble_duration * 0.5 * skill), NONE, target, BUSY_ICON_UNSKILLED))
 			return
 	user.visible_message(span_green("[user] starts searching for shrapnel in [target] with the [removaltool]."), span_green("You start searching for shrapnel in [target] with the [removaltool]."))
 	if(!do_after(user, do_after_time, NONE, target, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))


### PR DESCRIPTION
## `Основные изменения`
Время фамбла перед вытаскиванием шрапнели уменьшено вдвое, за счёт переделки формулы.
## `Как это улучшит игру`
Эта формула была говном по 2-ум причинам:

1. Вместо логичного сокращения времени фамбла для людей обладающих мед. навыком выше полного нуля (СЛ-ы), оно просто умножало время для всех у кого навык медицины был ниже СЛ-ского.
2. Она нигде не задокументирована, узнать о ней можно только найдя в самом коде. Все изменения вытаскивания шрапнели были сделаны без её учёта.

Из-за этого при задуманном времени фамбла в 12 секунд, обычные мары получали 24 секунд ожидания, помимо 30 урона на конечности, что может привести к легкому перелому.
## `Ченджлог`
```
:cl:
balance: Время фамбла перед вытаскиванием шрапнели уменьшено вдвое, за счёт переделки формулы.
/:cl:
```
