### PR TITLE
Завод теперь может производить снаряды для ФК88 и танковые снаряды для главного орудия

### DIFF
--- a/code/modules/reqtorio/assembly_crafts.dm
+++ b/code/modules/reqtorio/assembly_crafts.dm
@@ -305,3 +305,28 @@ WEAPONS
 	name = "MLRS High Explosive rocket"
 	input = list(/obj/item/stack/sheet/plasteel = 3, /obj/item/stack/gun_powder = 3) // 24 + 24 points
 	output = list(/obj/item/storage/box/mlrs_rockets = 1) // 33 points from old factory
+
+/datum/assembly_craft/weapons/ltb_shells
+	name = "LTB tank shell"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 5)
+	output = list(/obj/item/ammo_magazine/tank/ltb_cannon = 1)
+
+/datum/assembly_craft/weapons/ltb_cannon_apfds
+	name = "LTB tank APFDS shell"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 2, /obj/item/stack/gun_powder = 3)
+	output = list(/obj/item/ammo_magazine/tank/ltb_cannon/apfds = 1)
+
+/datum/assembly_craft/weapons/ltb_cannon_TOW
+	name = "LTB TOW magazine"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 3, /obj/item/stack/gun_powder = 6)
+	output = list(/obj/item/ammo_magazine/tank/towlauncher = 1)
+
+/datum/assembly_craft/weapons/heavy_isg_he
+	name = "A 15cm HE shell for the FK-88 mounted flak gun."
+	input = list(/obj/item/stack/sheet/jeweler_steel = 25, /obj/item/stack/gun_powder = 30)
+	output = list(/obj/item/ammo_magazine/heavy_isg/he = 1)
+
+/datum/assembly_craft/weapons/heavy_isg_sabot
+	name = "A 15cm APFDS shell for the FK-88 mounted flak gun"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 30, /obj/item/stack/gun_powder = 25)
+	output = list(/obj/item/ammo_magazine/heavy_isg/sabot = 1)

--- a/code/modules/reqtorio/assembly_crafts.dm
+++ b/code/modules/reqtorio/assembly_crafts.dm
@@ -317,7 +317,7 @@ WEAPONS
 	output = list(/obj/item/ammo_magazine/tank/ltb_cannon/apfds = 1)
 
 /datum/assembly_craft/weapons/ltb_cannon_TOW
-	name = "LTB TOW magazine"
+	name = "TOW Launcher Magazine"
 	input = list(/obj/item/stack/sheet/jeweler_steel = 3, /obj/item/stack/gun_powder = 6)
 	output = list(/obj/item/ammo_magazine/tank/towlauncher = 1)
 

--- a/code/modules/vehicles/armored/ammo_magazine.dm
+++ b/code/modules/vehicles/armored/ammo_magazine.dm
@@ -22,6 +22,16 @@
 	icon_state = "ltb_apfds"
 	default_ammo = /datum/ammo/bullet/tank_apfds
 
+/obj/item/ammo_magazine/tank/towlauncher
+	name = "TOW Launcher Magazine"
+	desc = "A primary armament rocket magazine"
+	caliber = CALIBER_68MM
+	icon_state = "quad_rocket"
+	icon = 'icons/obj/items/ammo/rocket.dmi'
+	w_class = WEIGHT_CLASS_GIGANTIC
+	default_ammo = /datum/ammo/rocket/ap //Fun fact, AP rockets seem to be a straight downgrade from normal rockets. Maybe I'm missing something...
+	max_rounds = 5
+
 /obj/item/ammo_magazine/tank/ltaap_chaingun
 	name = "\improper LTA-AP chaingun Magazine"
 	desc = "A primary armament chaingun magazine."
@@ -41,16 +51,6 @@
 	w_class = WEIGHT_CLASS_GIGANTIC
 	default_ammo = /datum/ammo/flamethrower/tank_flamer
 	max_rounds = 120
-
-/obj/item/ammo_magazine/tank/towlauncher
-	name = "TOW Launcher Magazine"
-	desc = "A secondary armament rocket magazine"
-	caliber = CALIBER_68MM
-	icon_state = "quad_rocket"
-	icon = 'icons/obj/items/ammo/rocket.dmi'
-	w_class = WEIGHT_CLASS_GIGANTIC
-	default_ammo = /datum/ammo/rocket/ap //Fun fact, AP rockets seem to be a straight downgrade from normal rockets. Maybe I'm missing something...
-	max_rounds = 5
 
 /obj/item/ammo_magazine/tank/secondary_cupola
 	name = "M56 Cupola Magazine"


### PR DESCRIPTION
## `Основные изменения`
Завод который может производить как садары так и поды может производить снаряды повышенного калибра
## `Как это улучшит игру`
Цены:
ХЕ танковый снаряд - 1 ювелирная сталь, 5 пороха
Бронебойный танковый снаряд - 2 ювелирных стали, 3 пороха
TOW танковый магазин - 3 ювелирных стали, 6 пороха
ХЕ снаряд ФК88 -  25 ювелирной стали, 30 пороха
Бронебойный снаряд ФК88 - 30 ювелирной стали, 25 пороха
## `Ченджлог`
```
:cl:
balance: Завод может производить снаряды для ФК88 и главного орудия танка
fix: Описание TOW магазина для главного орудия танка исправлено
/:cl:
```
