### PR TITLE
widow bugfix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -164,6 +164,9 @@
 	if(owner.do_actions)
 		return fail_activate()
 
+	if(current_charges <= 0)
+		return fail_activate()
+
 	var/mob/living/carbon/xenomorph/X = owner
 	if(length(spiderlings) >= X.xeno_caste.max_spiderlings)
 		X.balloon_alert(X, "Max Spiderlings")


### PR DESCRIPTION
## `Основные изменения`
Создать спайдерлинга больше нельзя если у абилки нет зарядов

## `Ченджлог`
```
:cl:
fix: Создать спайдерлинга больше нельзя если у абилки нет зарядов
/:cl:
```
