### PR TITLE
Tank is shitspawn only now

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -20,7 +20,7 @@
 		/datum/job/terragov/civilian/clown = -1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
-		/datum/job/terragov/command/assault_crewman = 2,
+		/datum/job/terragov/command/assault_crewman = 0,
 		/datum/job/terragov/command/transport_crewman = 1,
 		/datum/job/terragov/silicon/ai = 1,
 		/datum/job/terragov/squad/engineer = 8,

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -20,7 +20,7 @@
 		/datum/job/terragov/civilian/clown = -1,
 		/datum/job/terragov/silicon/synthetic = 1,
 		/datum/job/terragov/command/mech_pilot = 0,
-		/datum/job/terragov/command/assault_crewman = 2,
+		/datum/job/terragov/command/assault_crewman = 0,
 		/datum/job/terragov/command/transport_crewman = 1,
 		/datum/job/terragov/silicon/ai = 1,
 		/datum/job/terragov/squad/engineer = 1,


### PR DESCRIPTION
## `Основные изменения`
Танк теперь можно получить только с помощью щитспавна. АПЦ не тронуто

## `Как это улучшит игру`

Убираем гибпушку подальше от рук простых игроков. Улучшаем геймплей обеим сторонам.

## `Ченджлог`
```
:cl:
code: За ассаулт крюмана больше нельзя зайти, соответственно танк получить больше нельзя
/:cl:
```
