### PR TITLE
Tank nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -76,14 +76,14 @@
 	hud_state = "bigshell_he"
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	cell_explosion(T, 160, 70)
+	cell_explosion(T, 320, 70)
 
 /datum/ammo/bullet/tank_apfds
 	name = "8.8cm APFDS round"
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 150
+	damage = 300
 	penetration = 75
 	shell_speed = 4
 	accurate_range = 24

--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -76,14 +76,14 @@
 	hud_state = "bigshell_he"
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
-	cell_explosion(T, 320, 70)
+	cell_explosion(T, 160, 70)
 
 /datum/ammo/bullet/tank_apfds
 	name = "8.8cm APFDS round"
 	icon_state = "apfds"
 	hud_state = "bigshell_apfds"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
-	damage = 300
+	damage = 150
 	penetration = 75
 	shell_speed = 4
 	accurate_range = 24

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -608,7 +608,7 @@
 	var/list/leftright = LeftAndRightOfDir(turret_overlay.dir)
 	var/left = leftright[1] - 1
 	var/right = leftright[2] + 1
-	if(!(left == (new_weapon_dir-1)) && !(right == (new_weapon_dir+1)))
+	if(left != (new_weapon_dir - 1) && right != (new_weapon_dir + 1))
 		return FALSE
 	if(turret_overlay.dir == new_weapon_dir)
 		return FALSE

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -605,6 +605,11 @@
 /obj/vehicle/sealed/armored/proc/swivel_turret(atom/A, new_weapon_dir)
 	if(!new_weapon_dir)
 		new_weapon_dir = angle_to_cardinal_dir(Get_Angle(get_turf(src), get_turf(A)))
+	var/list/leftright = LeftAndRightOfDir(turret_overlay.dir)
+	var/left = leftright[1] - 1
+	var/right = leftright[2] + 1
+	if(!(left == (new_weapon_dir-1)) && !(right == (new_weapon_dir+1)))
+		return FALSE
 	if(turret_overlay.dir == new_weapon_dir)
 		return FALSE
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_TANK_SWIVEL)) //Slight cooldown to avoid spam

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -16,8 +16,8 @@
 	light_pixel_y= 32
 	pixel_x = -56
 	pixel_y = -48
-	max_integrity = 900
-	soft_armor = list(MELEE = 50, BULLET = 99 , LASER = 99, ENERGY = 60, BOMB = 60, BIO = 60, FIRE = 50, ACID = 50)
+	max_integrity = 600
+	soft_armor = list(MELEE = 40, BULLET = 99 , LASER = 99, ENERGY = 60, BOMB = 60, BIO = 60, FIRE = 50, ACID = 40)
 	hard_armor = list(MELEE = 0, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	permitted_mods = list(/obj/item/tank_module/overdrive, /obj/item/tank_module/ability/zoom)
 	permitted_weapons = list(/obj/item/armored_weapon, /obj/item/armored_weapon/ltaap, /obj/item/armored_weapon/secondary_weapon, /obj/item/armored_weapon/secondary_flamer)

--- a/code/modules/vehicles/armored/_multitile.dm
+++ b/code/modules/vehicles/armored/_multitile.dm
@@ -16,7 +16,7 @@
 	light_pixel_y= 32
 	pixel_x = -56
 	pixel_y = -48
-	max_integrity = 600
+	max_integrity = 700
 	soft_armor = list(MELEE = 40, BULLET = 99 , LASER = 99, ENERGY = 60, BOMB = 60, BIO = 60, FIRE = 50, ACID = 40)
 	hard_armor = list(MELEE = 0, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	permitted_mods = list(/obj/item/tank_module/overdrive, /obj/item/tank_module/ability/zoom)

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -32,7 +32,7 @@
 	///windup sound played during windup
 	var/windup_sound
 	///windup delay for this object
-	var/windup_delay = 0
+	var/windup_delay = 5
 	///scatter of this weapon. in degrees and modified by arm this is attached to
 	var/variance = 0
 	/// since mech guns only get one firemode this is for all types of shots


### PR DESCRIPTION
## `Основные изменения`
ХП уменьшено до 700.
Броня от мили и ацида уменьшены до 40.
Башня танка теперь поворачивается только в соседние стороны.
Добавлен небольшой виндап перед выстрелом.

## `Как это улучшит игру`

Нерф бесплатной ваншот коробки с миллион ХП.

## `Ченджлог`
```
:cl:
add: Башня танка теперь поворачивается только в соседние стороны.
add: Пушке танка добавлен виндап в 0.5 секунды перед выстрелом.
balance: ХП танка с 900 уменьшено до 700.
balance: Броня танка от мили и ацида уменьшены с 50 до 40.
/:cl:
```
