### PR TITLE
Gives hunter vampirism

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -660,7 +660,7 @@
 
 /datum/action/ability/xeno_action/crippling_strike/hunter
 	additional_damage = 1
-	heal_amount = 0
+	heal_amount = 12
 	plasma_gain = 20
 	decay_time = 15 SECONDS
 


### PR DESCRIPTION
## `Основные изменения`
Вампиризм охотнику, после набивания пяти стаков крипплинг страйк начинает восстанавливать по 12 ХП за удар

## `Как это улучшит игру`

У хантера мало ХП и брони, такая низкая выживаемость должна компенсироваться абилкой, которая эту выживаемость будет повышать. В данном случае - вампиризм.
```
:cl:
balance: Добавил Хантеру вампиризм.
/:cl:
```
