### PR TITLE
Уменьшил количество алярмов и апц на Призонке

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -160,6 +160,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "aaJ" = (
@@ -1864,6 +1867,9 @@
 /area/prison/research/secret/containment)
 "ahA" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison/whitepurple,
 /area/prison/research/secret/bioengineering)
 "ahB" = (
@@ -1878,6 +1884,7 @@
 /area/prison/research/secret/containment)
 "ahC" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/darkpurple{
 	dir = 1
 	},
@@ -2520,6 +2527,7 @@
 /area/prison/research/secret/containment)
 "aju" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/darkpurple{
 	dir = 1
 	},
@@ -3132,6 +3140,9 @@
 "alm" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research/secret/chemistry)
 "aln" = (
@@ -4022,6 +4033,7 @@
 /area/prison/maintenance/research_medbay)
 "anQ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -4676,6 +4688,9 @@
 "apS" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/research/RD)
 "apT" = (
@@ -5837,6 +5852,9 @@
 "ato" = (
 /obj/structure/displaycase/destroyed,
 /obj/item/shard,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
 /turf/open/floor/marking/bot,
 /area/prison/research/RD)
 "atp" = (
@@ -6652,6 +6670,7 @@
 /area/prison/hangar_storage/research)
 "avJ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/bright_clean,
 /area/prison/chapel)
 "avK" = (
@@ -6954,6 +6973,9 @@
 "awG" = (
 /obj/structure/bed/roller,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -7133,6 +7155,7 @@
 /area/prison/security/checkpoint/maxsec)
 "axo" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "axq" = (
@@ -7204,6 +7227,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/power/apc,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "axC" = (
@@ -8014,6 +8038,9 @@
 /area/prison/hallway/central)
 "aAc" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/medbay/foyer)
 "aAd" = (
@@ -8863,6 +8890,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aCF" = (
@@ -8935,20 +8965,15 @@
 	},
 /area/prison/hangar_storage/main)
 "aCO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/air_alarm{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred,
-/area/prison/security/checkpoint/maxsec)
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/central)
 "aCP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -9154,6 +9179,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1
 	},
 /turf/open/floor/prison/whitepurple,
 /area/prison/research)
@@ -9554,6 +9582,9 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "aEL" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -9794,6 +9825,9 @@
 "aFF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
 "aFG" = (
@@ -10966,6 +11000,9 @@
 /area/prison/research)
 "aJh" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/air_alarm{
+	dir = 1
+	},
 /turf/open/floor/prison/whitepurple,
 /area/prison/research)
 "aJi" = (
@@ -11521,6 +11558,7 @@
 /area/prison/storage/highsec/n)
 "aKD" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/bright_clean,
 /area/prison/cleaning)
 "aKE" = (
@@ -11624,6 +11662,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/power/apc,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -12128,6 +12167,9 @@
 "aMm" = (
 /obj/structure/bed/chair/comfy,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/prison/command/office)
 "aMo" = (
@@ -12433,6 +12475,9 @@
 /area/prison/security/monitoring/lowsec/ne)
 "aNt" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
 "aNu" = (
@@ -12753,6 +12798,7 @@
 /area/prison/quarters/staff)
 "aOB" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -13555,6 +13601,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/red{
 	dir = 6
 	},
@@ -13914,6 +13963,7 @@
 /area/prison/engineering/atmos)
 "aRY" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/green{
 	dir = 5
 	},
@@ -13951,6 +14001,9 @@
 /area/prison/cellblock/lowsec/nw)
 "aSh" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
 "aSi" = (
@@ -14047,6 +14100,7 @@
 /area/prison/recreation/staff)
 "aSA" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
 "aSD" = (
@@ -14085,6 +14139,9 @@
 "aSI" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/air_alarm{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/prison/command/office)
@@ -14230,6 +14287,9 @@
 "aTm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
 "aTn" = (
@@ -14343,6 +14403,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -14401,6 +14464,9 @@
 /area/prison/residential/north)
 "aTV" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/green{
 	dir = 4
 	},
@@ -14882,6 +14948,7 @@
 	on = 1
 	},
 /obj/effect/landmark/weed_node,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/canteen)
 "aVd" = (
@@ -15291,6 +15358,9 @@
 /turf/open/floor/prison/blue,
 /area/prison/command/secretary_office)
 "aWl" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
 /turf/open/floor/prison/blue{
 	dir = 6
 	},
@@ -15533,6 +15603,9 @@
 "aWZ" = (
 /obj/structure/rack,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "aXa" = (
@@ -16572,6 +16645,7 @@
 /area/prison/recreation/staff)
 "bat" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -17895,6 +17969,9 @@
 /area/prison/residential/central)
 "beJ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison/blue,
 /area/prison/cellblock/vip)
 "beL" = (
@@ -18162,6 +18239,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/power/apc,
 /turf/open/floor/prison/plate,
 /area/prison/toilet/canteen)
 "bfH" = (
@@ -18257,6 +18335,9 @@
 /area/prison/kitchen)
 "bfQ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/plate,
 /area/prison/hallway/entrance)
 "bfR" = (
@@ -19962,6 +20043,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/machinery/air_alarm{
+	dir = 1
+	},
 /turf/open/floor/prison/plate,
 /area/prison/toilet/canteen)
 "bkO" = (
@@ -20034,6 +20118,7 @@
 /area/prison/security/monitoring/highsec)
 "bkZ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/visitation)
 "bla" = (
@@ -20801,6 +20886,7 @@
 /area/prison/toilet/canteen)
 "bnJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -21386,6 +21472,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/holding/holding1)
 "bpc" = (
@@ -21612,6 +21701,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/store)
@@ -22860,6 +22952,9 @@
 /area/prison/visitation)
 "bun" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "buo" = (
@@ -22957,6 +23052,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -23122,6 +23218,9 @@
 /area/prison/holding/holding1)
 "buZ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
 "bva" = (
@@ -23343,6 +23442,9 @@
 "bvR" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
 "bvS" = (
@@ -24665,6 +24767,7 @@
 "bAM" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -25347,6 +25450,9 @@
 /area/prison/maintenance/residential/se)
 "bDr" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkbrown{
 	dir = 8
 	},
@@ -25986,6 +26092,9 @@
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
 "bFl" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
 /turf/open/floor/prison/green{
 	dir = 10
 	},
@@ -26054,6 +26163,7 @@
 /area/prison/cellblock/lowsec/se)
 "bFz" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
 "bFA" = (
@@ -26081,6 +26191,9 @@
 /area/prison/hallway/central)
 "bFE" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/prison/parole/main)
 "bFF" = (
@@ -27376,6 +27489,9 @@
 /area/prison/holding/holding2)
 "bJU" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/toilet/security)
 "bJV" = (
@@ -28234,6 +28350,7 @@
 /area/prison/laundry)
 "bMP" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
 "bMQ" = (
@@ -28839,6 +28956,9 @@
 /area/prison/parole/main)
 "bOM" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -29616,6 +29736,7 @@
 /area/prison/residential/central)
 "bRE" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -30186,6 +30307,9 @@
 /area/prison/recreation/medsec)
 "bTH" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/security/head)
 "bTI" = (
@@ -30694,6 +30818,9 @@
 "bVB" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -30865,6 +30992,7 @@
 /area/prison/engineering)
 "bWd" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/blue{
 	dir = 9
 	},
@@ -30918,6 +31046,7 @@
 "bWv" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison,
 /area/prison/execution)
 "bWw" = (
@@ -31636,6 +31765,7 @@
 "bYS" = (
 /obj/machinery/power/monitor,
 /obj/structure/cable,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/engineering)
 "bYT" = (
@@ -32005,6 +32135,7 @@
 /area/prison/cellblock/mediumsec/north)
 "can" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison,
 /area/prison/security/head)
 "cao" = (
@@ -32122,6 +32253,9 @@
 /area/prison/security)
 "caK" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/execution)
 "caL" = (
@@ -32316,6 +32450,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
+/obj/machinery/power/apc{
+	dir = 8
+	},
 /turf/open/floor/prison/darkred{
 	dir = 4
 	},
@@ -32454,6 +32591,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/weed_node,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -33282,6 +33422,9 @@
 /area/prison/hallway/central)
 "cdZ" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 9
 	},
@@ -33336,6 +33479,9 @@
 /area/prison/cellblock/mediumsec/north)
 "ceg" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec_medsec)
 "ceh" = (
@@ -33614,6 +33760,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/machinery/power/apc,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -34463,6 +34610,9 @@
 /area/prison/security/briefing)
 "chX" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/west)
 "chY" = (
@@ -34777,6 +34927,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/air_alarm,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cjd" = (
@@ -35099,6 +35250,7 @@
 /area/prison/security/head)
 "cki" = (
 /obj/structure/cable,
+/obj/machinery/power/apc,
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -35120,6 +35272,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -36173,6 +36328,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "cnp" = (
@@ -37932,6 +38090,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/machinery/power/apc,
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -39880,6 +40039,14 @@
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"diA" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/whitepurple{
+	dir = 6
+	},
+/area/prison/research/secret/biolab)
 "diW" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -40006,6 +40173,14 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"due" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
 "duu" = (
 /obj/machinery/light{
 	dir = 4
@@ -40115,6 +40290,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
+"dLb" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/tool/kitchen/rollingpin,
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/south)
 "dLE" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -40283,6 +40467,18 @@
 	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
+"edG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "edY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -40629,6 +40825,11 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/highsec/north/south)
+"eEj" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/prison,
+/area/prison/research/secret/dissection)
 "eEC" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/chapel{
@@ -40680,6 +40881,12 @@
 "eOr" = (
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
+"eOE" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/prison/recreation/staff)
 "eOG" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/whitepurple,
@@ -40713,6 +40920,14 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
+"eRg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/north)
 "eSE" = (
 /turf/open/ground/coast{
 	dir = 1
@@ -40845,6 +41060,7 @@
 /turf/open/ground/coast,
 /area/prison/cellblock/maxsec/south)
 "fgQ" = (
+/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -40926,6 +41142,11 @@
 "fpI" = (
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
+"fqG" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/hallway/central)
 "frn" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
@@ -40965,6 +41186,14 @@
 /obj/structure/lattice,
 /turf/open/space/sea,
 /area/space)
+"fvj" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred{
+	dir = 6
+	},
+/area/prison/security/monitoring/highsec)
 "fvF" = (
 /obj/machinery/flasher{
 	id = "suspended_WES"
@@ -41408,6 +41637,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
+"gyS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "gzk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -41438,6 +41674,16 @@
 /obj/structure/flora/pottedplant,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"gCJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "gCS" = (
 /obj/machinery/light{
 	dir = 4
@@ -41489,6 +41735,19 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/north/south)
+"gHc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/east)
 "gIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41587,6 +41846,13 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
+"gPb" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
 "gPc" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating,
@@ -41759,6 +42025,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
+"hgR" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/disposal)
 "hgT" = (
 /obj/effect/spawner/random/weaponry/shiv,
 /turf/open/floor/prison/marked,
@@ -41857,6 +42130,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/biolab)
+"huk" = (
+/obj/structure/flora/pottedplant,
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/prison/residential/central)
 "huy" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/extinguisher/regularweighted,
@@ -41966,6 +42246,15 @@
 /obj/item/tool/kitchen/tray,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"hHG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
+	},
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/prison/residential/central)
 "hJL" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green,
@@ -42054,6 +42343,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"hOE" = (
+/obj/structure/closet/crate/freezer,
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/prison/kitchen,
+/area/prison/kitchen)
 "hPs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -42122,6 +42417,17 @@
 /obj/effect/spawner/random/engineering/structure/tank/waterweighted,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"hUL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
 "hVf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
@@ -42212,6 +42518,15 @@
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
+"ifN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/staff_research)
 "igm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42397,6 +42712,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"iAi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/north)
 "iAE" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkpurple{
@@ -42672,6 +42995,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
+"jce" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "jcV" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/darkred/full,
@@ -42693,6 +43022,15 @@
 	},
 /turf/open/floor/prison/plate,
 /area/prison/hallway/engineering)
+"jeR" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/civilian)
 "jfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -42768,6 +43106,7 @@
 /area/prison/toilet/canteen)
 "jjo" = (
 /obj/effect/landmark/weed_node,
+/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -42936,6 +43275,13 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/hangar/main)
+"jCp" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/turf/open/floor/prison/whitepurple,
+/area/prison/research/secret/biolab)
 "jCG" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -42991,6 +43337,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/maxsec/south)
+"jFX" = (
+/obj/structure/table/woodentable,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/prison/residential/south)
 "jGu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -43234,6 +43587,24 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/vip)
+"kgf" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
+"kgK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
 "khD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
@@ -43312,6 +43683,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/marked,
 /area/prison/hangar_storage/main)
+"kpk" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/prison/medbay)
 "kpA" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/bright_clean/two,
@@ -43689,6 +44066,17 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"ldD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/checkpoint/maxsec)
 "ldL" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -43794,6 +44182,10 @@
 "lqx" = (
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/east)
+"lra" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/wood,
+/area/prison/chapel)
 "lrg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -43987,6 +44379,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
+"lMG" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/turf/open/floor/prison/green,
+/area/prison/cellblock/lowsec/se)
 "lOl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -44017,6 +44416,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"lQH" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/prison/disposal)
 "lQK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44059,6 +44465,17 @@
 	dir = 4
 	},
 /area/prison/hangar/civilian)
+"lUN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "lXn" = (
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
@@ -44094,6 +44511,11 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"mcu" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/residential/north)
 "mee" = (
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/floor/wood,
@@ -44134,6 +44556,16 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"mmy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "mmI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
@@ -44172,6 +44604,9 @@
 "mnR" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "mof" = (
@@ -44194,6 +44629,23 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/hangar/main)
+"moP" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/wood,
+/area/prison/library)
+"mqz" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/prison/cellblock/maxsec/north)
+"mri" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/engineering)
 "mrj" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/yellow/corner{
@@ -44550,6 +45002,19 @@
 	dir = 6
 	},
 /area/prison/security/checkpoint/highsec/s)
+"mXN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/turf/open/floor/prison/green,
+/area/prison/hallway/staff)
 "mYk" = (
 /obj/structure/sink,
 /turf/open/floor/prison/cellstripe{
@@ -44654,6 +45119,17 @@
 	dir = 1
 	},
 /area/prison/security/monitoring/lowsec/ne)
+"nen" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "neS" = (
 /turf/open/floor/prison/darkred{
 	dir = 5
@@ -44726,6 +45202,20 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
+"nkc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc,
+/turf/open/floor/prison/yellow/full,
+/area/prison/security/checkpoint/medsec)
 "nkA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -44800,6 +45290,11 @@
 /obj/structure/stairs/seamless/platform,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
+"nuP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "nvD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44993,6 +45488,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"nPh" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "nPq" = (
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric{
 	dir = 1;
@@ -45113,6 +45614,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"nZI" = (
+/obj/structure/closet/crate/freezer,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/kitchen)
 "oal" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -45464,10 +45972,32 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"oOD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/north)
 "oPA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"oPL" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/visitation)
+"oQD" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
 "oRe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -45780,6 +46310,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"pDf" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
+/turf/open/floor/prison/green/full,
+/area/prison/monorail/west)
 "pDn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45873,6 +46410,19 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
+"pIw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/power/apc,
+/turf/open/floor/prison/whitepurple{
+	dir = 1
+	},
+/area/prison/quarters/research)
 "pIy" = (
 /turf/open/ground/coast/corner2,
 /area/prison/maintenance/residential/access/north)
@@ -46211,6 +46761,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
+"qlz" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/north/south)
 "qlA" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison/sterilewhite,
@@ -46269,6 +46827,14 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
+"quA" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/darkpurple{
+	dir = 4
+	},
+/area/prison/research/secret/containment)
 "quF" = (
 /obj/structure/sink,
 /turf/open/floor/prison/cellstripe{
@@ -46571,6 +47137,12 @@
 	},
 /turf/open/floor/wood/broken,
 /area/prison/residential/central)
+"qWy" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/prison/security/monitoring/highsec)
 "qWz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -46709,6 +47281,12 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/prison/plate,
 /area/prison/research/secret/biolab)
+"rjt" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
 "rjM" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green{
@@ -47013,6 +47591,9 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "rGT" = (
@@ -47306,6 +47887,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
+"snD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/prison/green{
+	dir = 8
+	},
+/area/prison/cellblock/lowsec/ne)
 "snZ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
@@ -47373,6 +47966,13 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"ssA" = (
+/obj/structure/closet/secure_closet/medical3/colony,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/whitegreen/full,
+/area/prison/medbay)
 "ssR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47630,6 +48230,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue,
 /area/prison/cellblock/protective)
+"sMO" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/prison/green{
+	dir = 6
+	},
+/area/prison/cellblock/lowsec/se)
 "sNa" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/ai_node,
@@ -47642,6 +48250,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/entrance)
+"sOx" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/quarters/security)
 "sOM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47800,6 +48415,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/prison,
 /area/prison/engineering)
+"thC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "tjY" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/prison,
@@ -47969,10 +48591,22 @@
 /obj/effect/spawner/modularmap/prison/civressouth,
 /turf/template_noop,
 /area/prison/residential/south)
+"tyR" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
+/area/prison/hangar_storage/main)
 "tzx" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"tAh" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/wood,
+/area/prison/parole/protective_custody)
 "tAo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -48181,6 +48815,11 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/east)
+"tXS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/prison,
+/area/prison/medbay/morgue)
 "tYu" = (
 /obj/structure/sink{
 	dir = 8
@@ -48353,6 +48992,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
+"uop" = (
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/prison/security/briefing)
 "uoO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -48410,6 +49056,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/bright_clean,
 /area/prison/chapel)
+"uvt" = (
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/green{
+	dir = 6
+	},
+/area/prison/cellblock/lowsec/nw)
 "uvz" = (
 /obj/structure/flora/pottedplant/ten,
 /turf/open/floor/plating,
@@ -48473,6 +49127,15 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/lowsec/sw)
+"uDL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/prison/residential/south)
 "uDV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -48484,6 +49147,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
+"uEy" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "uGi" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/plating/platebot,
@@ -48630,6 +49300,14 @@
 	dir = 9
 	},
 /area/prison/hangar/civilian)
+"uXu" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/prison/whitepurple{
+	dir = 8
+	},
+/area/prison/research/secret/bioengineering)
 "uXI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
@@ -48677,6 +49355,13 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/south/south)
+"vdj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/air_alarm,
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "vdD" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -48757,6 +49442,12 @@
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
+"vle" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/prison/residential/south)
 "vlk" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -49322,6 +50013,12 @@
 	dir = 9
 	},
 /area/prison/hangar/main)
+"wul" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/prison/security/briefing)
 "wus" = (
 /obj/machinery/shower{
 	dir = 4
@@ -49469,6 +50166,17 @@
 	},
 /turf/open/floor/wood,
 /area/prison/residential/south)
+"wFm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc,
+/turf/open/floor/prison,
+/area/prison/security/monitoring/highsec)
 "wHb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49530,6 +50238,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
+"wMv" = (
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/research/secret/dissection)
 "wMM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49651,6 +50365,17 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
 /area/prison/cellblock/mediumsec/south)
+"xax" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
 "xaR" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
@@ -49695,6 +50420,15 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"xfW" = (
+/obj/structure/filingcabinet,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred{
+	dir = 4
+	},
+/area/prison/security/monitoring/medsec/south)
 "xgj" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -49746,6 +50480,9 @@
 /area/prison/cellblock/maxsec/north)
 "xly" = (
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -49948,6 +50685,13 @@
 /obj/machinery/gibber,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"xHw" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
+/area/prison/hangar_storage/main)
 "xHS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -55002,7 +55746,7 @@ aRS
 aRS
 pYD
 amu
-mRK
+kgf
 qhf
 inq
 inq
@@ -56016,7 +56760,7 @@ aym
 tnZ
 aJE
 aKs
-aLb
+thC
 akC
 aMB
 aRT
@@ -56038,7 +56782,7 @@ bcH
 uVZ
 gWR
 gWR
-aAC
+jeR
 ays
 ubZ
 bkv
@@ -56330,7 +57074,7 @@ bMB
 bLL
 syI
 bKo
-bLO
+dLb
 bGU
 bTD
 bVl
@@ -56852,7 +57596,7 @@ bGU
 klX
 bMC
 bMC
-ccu
+uDL
 bGU
 bXo
 bIh
@@ -57288,7 +58032,7 @@ avl
 avO
 awl
 avN
-axF
+nuP
 ayk
 xBx
 azi
@@ -58331,7 +59075,7 @@ aBV
 avN
 axG
 axG
-axG
+jce
 avN
 iqK
 uZP
@@ -58638,7 +59382,7 @@ bIk
 bGU
 ppK
 iQO
-bGR
+jFX
 iQO
 bGU
 mYx
@@ -59386,7 +60130,7 @@ rqp
 brr
 axO
 iYA
-bRj
+huk
 aWr
 xwG
 aCC
@@ -60952,7 +61696,7 @@ bGU
 bGU
 bIT
 bLL
-bLL
+vle
 bGU
 bOc
 bNK
@@ -61148,7 +61892,7 @@ axG
 axG
 axG
 avN
-aDI
+mcu
 aDI
 aBV
 aBV
@@ -61915,7 +62659,7 @@ avM
 awr
 avM
 avN
-ayQ
+vdj
 azk
 azk
 axJ
@@ -62731,7 +63475,7 @@ qKk
 bbK
 bbK
 mwK
-bsZ
+aCO
 aWr
 buB
 bvs
@@ -63747,7 +64491,7 @@ aWo
 aXv
 aYQ
 aWr
-baQ
+hHG
 aWo
 aWo
 aWr
@@ -64282,7 +65026,7 @@ bsk
 bta
 byo
 bzw
-bzw
+pDf
 bsl
 bsl
 bsm
@@ -66826,7 +67570,7 @@ aaq
 bdI
 aZZ
 apo
-aZY
+qWy
 bcV
 aZY
 arQ
@@ -69669,7 +70413,7 @@ blZ
 bkX
 bqN
 baa
-bnw
+wFm
 oie
 bdI
 btz
@@ -69908,7 +70652,7 @@ bxR
 bxR
 bxR
 bxR
-bxR
+qlz
 lzI
 aGb
 bcZ
@@ -70134,7 +70878,7 @@ asX
 asX
 pbf
 pbf
-pbf
+hUL
 pbf
 acO
 pbf
@@ -70152,7 +70896,7 @@ aTT
 blW
 kyN
 kyN
-jKs
+edG
 kyN
 kyN
 kyN
@@ -71211,7 +71955,7 @@ bpl
 baa
 bqS
 blZ
-bqN
+fvj
 bgB
 sTW
 bdI
@@ -72694,7 +73438,7 @@ aab
 anA
 amW
 hVf
-pXu
+due
 pXu
 pXu
 hVf
@@ -72704,8 +73448,8 @@ ats
 pbf
 nZm
 pbf
-pbf
-pbf
+hUL
+xax
 aws
 ats
 nZm
@@ -72721,7 +73465,7 @@ agz
 bru
 kyN
 kyN
-kyN
+nen
 jAv
 eLE
 eLE
@@ -74017,7 +74761,7 @@ eCA
 eCA
 gJY
 eCA
-eCA
+mmy
 aXR
 aZd
 aLe
@@ -78577,7 +79321,7 @@ fyZ
 cPB
 cPB
 aes
-cPB
+eRg
 afc
 aqM
 foy
@@ -78585,7 +79329,7 @@ cPB
 seK
 cPB
 rfl
-cPB
+eRg
 seK
 cPB
 rfl
@@ -78877,7 +79621,7 @@ akK
 fYc
 adz
 axM
-ayD
+lra
 eWS
 ayD
 ayD
@@ -81668,7 +82412,7 @@ add
 pzM
 gxX
 ahv
-pzM
+mqz
 ajc
 vWu
 acK
@@ -81800,7 +82544,7 @@ ccV
 caq
 bQF
 ccV
-cnB
+kgK
 ctT
 cun
 ccA
@@ -81812,7 +82556,7 @@ cun
 ccA
 cuL
 cun
-xeX
+gPb
 ctj
 cun
 gUw
@@ -81824,7 +82568,7 @@ cun
 cuL
 ccA
 cun
-cxz
+rjt
 ctj
 cun
 cun
@@ -81948,7 +82692,7 @@ akV
 akV
 akV
 akV
-ofy
+gCJ
 akV
 izu
 vcw
@@ -82205,7 +82949,7 @@ amC
 amC
 utU
 amC
-drR
+lUN
 amC
 amC
 anK
@@ -83507,7 +84251,7 @@ azZ
 jYZ
 hKi
 jYZ
-aCO
+aCM
 aCW
 aCW
 aGx
@@ -83528,7 +84272,7 @@ aUr
 aPC
 aVE
 aYg
-aVG
+uvt
 aNp
 bbm
 aSi
@@ -83576,7 +84320,7 @@ bPE
 bPE
 bPz
 bPz
-bSW
+nkc
 bXe
 mBH
 xyg
@@ -83764,7 +84508,7 @@ jYZ
 jYZ
 azZ
 jYZ
-aCO
+aCM
 aCW
 aGy
 aGa
@@ -84014,7 +84758,7 @@ vOC
 xhO
 axS
 akK
-vJh
+ldD
 axQ
 axj
 axj
@@ -84876,7 +85620,7 @@ mBH
 sRe
 nOc
 cnb
-njY
+oOD
 njY
 njY
 njY
@@ -85170,7 +85914,7 @@ bju
 czl
 czB
 czN
-czN
+xfW
 cAa
 czU
 aab
@@ -85516,7 +86260,7 @@ fyZ
 cPB
 cPB
 aga
-cPB
+iAi
 afh
 afC
 aga
@@ -85524,7 +86268,7 @@ cPB
 fyZ
 cPB
 aga
-cPB
+iAi
 cPB
 cPB
 aga
@@ -86683,7 +87427,7 @@ ccV
 caq
 bXn
 ccV
-cnB
+kgK
 nKr
 cun
 daw
@@ -86695,7 +87439,7 @@ cun
 ccB
 cuL
 cun
-cxz
+rjt
 bgT
 cun
 cuL
@@ -86707,7 +87451,7 @@ cun
 cuL
 ccB
 cun
-lim
+oQD
 ctl
 cun
 cun
@@ -86855,7 +87599,7 @@ aGE
 aHU
 pIp
 aCW
-vSz
+fqG
 aLl
 aLx
 aLx
@@ -88346,7 +89090,7 @@ kVy
 svM
 svM
 afP
-agf
+jCp
 agt
 agt
 agt
@@ -88885,7 +89629,7 @@ agt
 anP
 anJ
 apt
-apM
+kpk
 gDz
 gDz
 avY
@@ -89384,7 +90128,7 @@ ahX
 aim
 aim
 aim
-aim
+quA
 ahT
 agL
 aks
@@ -90242,7 +90986,7 @@ bqs
 bqs
 bqs
 bEd
-bAa
+lMG
 bqs
 bqs
 bqs
@@ -90656,7 +91400,7 @@ adA
 aeI
 aek
 aeI
-aeY
+diA
 afj
 afj
 afj
@@ -90677,7 +91421,7 @@ agt
 alf
 ann
 ann
-gaZ
+wMv
 cnH
 gaZ
 ann
@@ -91211,7 +91955,7 @@ auW
 avw
 awe
 awP
-awP
+ssA
 awP
 apK
 azJ
@@ -91309,7 +92053,7 @@ cpU
 cpU
 cpU
 cpU
-coI
+gHc
 lqx
 cwc
 xAr
@@ -91434,7 +92178,7 @@ agj
 agv
 agv
 agv
-agv
+uXu
 ahG
 aib
 ain
@@ -91781,7 +92525,7 @@ bsL
 bqs
 byS
 sJB
-bAc
+sMO
 bqs
 bEj
 hrN
@@ -91960,7 +92704,7 @@ akd
 akB
 akP
 alg
-alM
+eEj
 alM
 alM
 alM
@@ -91975,7 +92719,7 @@ awS
 aGS
 asy
 atf
-auh
+tXS
 auh
 hqG
 hqG
@@ -92266,7 +93010,7 @@ aUR
 aVM
 vEk
 aWY
-aZq
+snD
 aZq
 aZq
 aZq
@@ -92567,7 +93311,7 @@ swF
 vSz
 sXO
 bPZ
-okw
+moP
 okw
 okw
 bVU
@@ -94055,7 +94799,7 @@ vSz
 swF
 oPA
 vSz
-aNt
+vSz
 vSz
 vSz
 vSz
@@ -94312,7 +95056,7 @@ aKQ
 swF
 alo
 bRS
-wfY
+bRS
 bRS
 alo
 bRS
@@ -96429,7 +97173,7 @@ ycx
 bRC
 bYX
 caA
-bUF
+mri
 ccn
 cbJ
 cft
@@ -97463,7 +98207,7 @@ cbW
 cfw
 cgF
 chH
-bZK
+tAh
 cjM
 ciU
 cjM
@@ -97732,7 +98476,7 @@ cpv
 cqk
 cmD
 crD
-csh
+lQH
 cpq
 aab
 aab
@@ -98161,7 +98905,7 @@ aED
 aED
 aED
 aED
-fIb
+pIw
 aKi
 blK
 aLH
@@ -98412,7 +99156,7 @@ eul
 eul
 eul
 pBH
-jfX
+gyS
 aDA
 aEA
 aFQ
@@ -99519,7 +100263,7 @@ cbW
 cfw
 cgI
 chN
-cjb
+hgR
 cjR
 ckQ
 clP
@@ -101539,7 +102283,7 @@ bxl
 bnG
 boV
 btt
-bul
+oPL
 iYm
 wCb
 bwX
@@ -101759,7 +102503,7 @@ buW
 aDB
 aHg
 aIl
-aDB
+ifN
 aKo
 mMb
 aDB
@@ -102024,7 +102768,7 @@ aHh
 aHh
 aNz
 iib
-aPS
+mXN
 aRs
 aSx
 aZM
@@ -102602,7 +103346,7 @@ qZb
 cev
 bQp
 cgN
-chT
+uop
 cjd
 cjY
 cjY
@@ -103065,7 +103809,7 @@ aQp
 aQp
 bay
 bdl
-bek
+hOE
 beF
 etf
 biz
@@ -103841,7 +104585,7 @@ aXh
 bhq
 bhq
 brx
-bek
+nZI
 bdl
 bmL
 bnI
@@ -104327,7 +105071,7 @@ aab
 aab
 aab
 aFV
-aHk
+xHw
 aIp
 aIo
 mBn
@@ -104345,7 +105089,7 @@ tNI
 aVk
 aVk
 aYz
-aVk
+eOE
 aTm
 aSz
 bcx
@@ -104584,7 +105328,7 @@ aab
 aab
 aab
 aFW
-jjo
+tyR
 aIo
 aIp
 gak
@@ -104658,7 +105402,7 @@ neV
 ikQ
 cfK
 cgN
-chW
+wul
 mJG
 cka
 cka
@@ -106436,7 +107180,7 @@ bAC
 bFL
 bAC
 bAC
-bJo
+sOx
 bAC
 bKL
 bLw
@@ -109511,7 +110255,7 @@ nTj
 gnJ
 bnQ
 pDQ
-bnQ
+nPh
 aYL
 bAK
 bnQ
@@ -109777,7 +110521,7 @@ gsU
 bzn
 ghl
 bGO
-foA
+uEy
 bIe
 hUJ
 ics

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -247,10 +247,6 @@
 "acK" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/cellblock/maxsec/north)
-"acL" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/cellblock/maxsec/north)
 "acM" = (
 /obj/machinery/light{
 	dir = 1
@@ -274,10 +270,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
-"acP" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/whitepurple/full,
-/area/prison/research/secret/bioengineering)
 "acQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -1425,13 +1417,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/whitepurple,
 /area/prison/research/secret/biolab)
-"age" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
-/turf/open/floor/prison/whitepurple,
-/area/prison/research/secret/biolab)
 "agf" = (
 /obj/structure/cable,
 /turf/open/floor/prison/whitepurple,
@@ -1446,7 +1431,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/air_alarm,
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "agi" = (
@@ -1820,7 +1804,6 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "aht" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -1834,7 +1817,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkpurple{
 	dir = 1
 	},
@@ -1882,9 +1864,6 @@
 /area/prison/research/secret/containment)
 "ahA" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/whitepurple,
 /area/prison/research/secret/bioengineering)
 "ahB" = (
@@ -1899,7 +1878,6 @@
 /area/prison/research/secret/containment)
 "ahC" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/darkpurple{
 	dir = 1
 	},
@@ -2229,12 +2207,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison/whitepurple,
 /area/prison/research/secret/bioengineering)
-"aiw" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkpurple{
-	dir = 1
-	},
-/area/prison/research/secret)
 "aix" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2548,7 +2520,6 @@
 /area/prison/research/secret/containment)
 "aju" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/darkpurple{
 	dir = 1
 	},
@@ -2561,10 +2532,6 @@
 	dir = 1
 	},
 /area/prison/research/secret/containment)
-"ajw" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkred/full,
-/area/prison/cellblock/maxsec/north)
 "ajy" = (
 /obj/machinery/light{
 	dir = 4
@@ -2617,10 +2584,6 @@
 	dir = 1
 	},
 /area/prison/research/secret)
-"ajE" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison,
-/area/prison/research/secret/dissection)
 "ajF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2667,11 +2630,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
-"ajM" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/prison,
-/area/prison/research/secret/dissection)
 "ajN" = (
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
@@ -2682,7 +2640,6 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "ajP" = (
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/whitepurple{
 	dir = 1
 	},
@@ -2799,7 +2756,6 @@
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
 "akm" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
@@ -3176,9 +3132,6 @@
 "alm" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research/secret/chemistry)
 "aln" = (
@@ -3249,9 +3202,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/north/south)
 "aly" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen{
 	dir = 4
@@ -4071,7 +4021,6 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
 "anQ" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 1
@@ -4511,11 +4460,6 @@
 	dir = 1
 	},
 /area/prison/security/checkpoint/maxsec_highsec)
-"apg" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/prison,
-/area/prison/medbay/morgue)
 "aph" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4732,9 +4676,6 @@
 "apS" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /turf/open/floor/prison,
 /area/prison/research/RD)
 "apT" = (
@@ -4905,9 +4846,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay/surgery)
 "aqB" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/red{
 	dir = 8
@@ -4982,9 +4920,6 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay/surgery)
 "aqQ" = (
-/obj/machinery/air_alarm{
-	dir = 4
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkpurple{
 	dir = 4
@@ -6011,17 +5946,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
-"atD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/cellblock/maxsec/south)
 "atE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6056,12 +5980,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
-"atI" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/whitepurple{
-	dir = 1
-	},
-/area/prison/research)
 "atJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6123,9 +6041,6 @@
 /area/prison/research/RD)
 "atS" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
 "atT" = (
@@ -6311,10 +6226,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/medsec)
-"auv" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/wood,
-/area/prison/chapel)
 "auw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -6740,7 +6651,6 @@
 /turf/open/floor/prison,
 /area/prison/hangar_storage/research)
 "avJ" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/chapel)
@@ -6815,9 +6725,6 @@
 /area/prison/cellblock/highsec/north/north)
 "avV" = (
 /obj/structure/rack,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/hangar_storage/research)
@@ -7020,13 +6927,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
-"awC" = (
-/obj/structure/bed/chair,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/north/north)
 "awD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7054,9 +6954,6 @@
 "awG" = (
 /obj/structure/bed/roller,
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /turf/open/floor/prison/whitegreen{
 	dir = 4
 	},
@@ -7135,10 +7032,6 @@
 	dir = 1
 	},
 /area/prison/research)
-"awT" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/access/north)
 "awU" = (
 /obj/machinery/photocopier,
 /turf/open/floor/prison/whitepurple{
@@ -7239,15 +7132,9 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "axo" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
-"axp" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/residential/north)
 "axq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -7440,22 +7327,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/chapel)
-"axY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
-/turf/open/floor/prison/darkred,
-/area/prison/security/checkpoint/maxsec)
 "axZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7810,9 +7681,6 @@
 /area/prison/medbay)
 "azf" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/whitepurple{
 	dir = 10
 	},
@@ -8003,11 +7871,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
-"azF" = (
-/obj/structure/bed/chair,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/medbay/foyer)
 "azH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop{
@@ -8151,9 +8014,6 @@
 /area/prison/hallway/central)
 "aAc" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/medbay/foyer)
 "aAd" = (
@@ -9003,9 +8863,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aCF" = (
@@ -9073,7 +8930,6 @@
 /area/prison/security/checkpoint/maxsec)
 "aCN" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/darkyellow{
 	dir = 5
 	},
@@ -9282,10 +9138,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/prison/darkred/full,
 /area/prison/medbay/foyer)
-"aDr" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/residential/north)
 "aDs" = (
 /obj/structure/sink{
 	dir = 4
@@ -9942,9 +9794,6 @@
 "aFF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
 "aFG" = (
@@ -10467,19 +10316,6 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research)
-"aGY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/whitepurple{
-	dir = 1
-	},
-/area/prison/quarters/research)
 "aGZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -10556,9 +10392,6 @@
 /area/prison/hangar_storage/main)
 "aHm" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple,
 /area/prison/quarters/research)
@@ -10601,7 +10434,6 @@
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/highsec/south/north)
 "aHu" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/storage/highsec/n)
@@ -11013,10 +10845,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
-"aIH" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/hallway/central)
 "aII" = (
 /turf/open/floor/prison/red{
 	dir = 10
@@ -11081,9 +10909,6 @@
 /area/prison/security/checkpoint/maxsec)
 "aIU" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/prison/maintenance/staff_research)
 "aIV" = (
@@ -11248,12 +11073,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/residential/north)
-"aJu" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/north/south)
 "aJv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11555,12 +11374,6 @@
 	dir = 10
 	},
 /area/prison/quarters/research)
-"aKg" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/green{
-	dir = 1
-	},
-/area/prison/hallway/staff)
 "aKh" = (
 /turf/open/floor/prison/whitepurple,
 /area/prison/quarters/research)
@@ -11706,14 +11519,8 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/prison,
 /area/prison/storage/highsec/n)
-"aKC" = (
-/obj/structure/bed/chair/comfy,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/green/full,
-/area/prison/cellblock/lowsec/nw)
 "aKD" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/bright_clean,
 /area/prison/cleaning)
 "aKE" = (
@@ -11811,7 +11618,6 @@
 /area/prison/hallway/central)
 "aKW" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -12321,9 +12127,6 @@
 /area/prison/quarters/research)
 "aMm" = (
 /obj/structure/bed/chair/comfy,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/prison/command/office)
@@ -12579,9 +12382,6 @@
 /area/prison/cellblock/highsec/north/south)
 "aNi" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/north/south)
 "aNj" = (
@@ -12690,9 +12490,6 @@
 /area/prison/hallway/staff)
 "aNC" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/green{
 	dir = 8
 	},
@@ -12844,10 +12641,6 @@
 /obj/structure/bed,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/ne)
-"aOf" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/nw)
 "aOg" = (
 /obj/machinery/computer/security{
 	network = list("PRISON")
@@ -12875,10 +12668,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison/bright_clean,
 /area/prison/cleaning)
-"aOo" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/ne)
 "aOp" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -12963,7 +12752,6 @@
 	},
 /area/prison/quarters/staff)
 "aOB" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 1
@@ -13693,7 +13481,6 @@
 /area/prison/command/secretary_office)
 "aQu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -13752,7 +13539,6 @@
 /area/prison/cellblock/highsec/north/south)
 "aQG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -14127,7 +13913,6 @@
 /turf/open/floor/prison/darkyellow,
 /area/prison/engineering/atmos)
 "aRY" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 5
@@ -14154,9 +13939,6 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/nw)
 "aSf" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/blue{
 	dir = 8
@@ -14169,9 +13951,6 @@
 /area/prison/cellblock/lowsec/nw)
 "aSh" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
 "aSi" = (
@@ -14268,7 +14047,6 @@
 /area/prison/recreation/staff)
 "aSA" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
 "aSD" = (
@@ -14428,9 +14206,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/red/full,
 /area/prison/security/checkpoint/highsec/n)
@@ -14439,11 +14214,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/highsec/n)
-"aTg" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
 "aTh" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/sterilewhite,
@@ -14458,9 +14228,6 @@
 	},
 /area/prison/cellblock/lowsec/nw)
 "aTm" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
@@ -14479,10 +14246,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/lowsec/nw)
-"aTp" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison,
-/area/prison/hallway/entrance)
 "aTr" = (
 /turf/open/floor/prison/green{
 	dir = 8
@@ -14637,9 +14400,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aTV" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 4
@@ -15057,7 +14817,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -15175,11 +14934,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
-"aVm" = (
-/obj/machinery/air_alarm,
-/obj/effect/ai_node,
-/turf/open/floor/prison,
-/area/prison/hangar/main)
 "aVn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15778,9 +15532,6 @@
 /area/prison/cellblock/lowsec/ne)
 "aWZ" = (
 /obj/structure/rack,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
@@ -15830,9 +15581,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
 "aXh" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -16012,9 +15760,6 @@
 /area/prison/security/monitoring/maxsec/panopticon)
 "aXI" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -16086,10 +15831,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
-"aXY" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean,
-/area/prison/yard)
 "aXZ" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light,
@@ -16234,12 +15975,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison/plate,
 /area/prison/hallway/staff)
-"aYx" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkred{
-	dir = 1
-	},
-/area/prison/security/monitoring/highsec)
 "aYz" = (
 /obj/machinery/light{
 	dir = 4
@@ -16293,12 +16028,7 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
-"aYG" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean,
-/area/prison/canteen)
 "aYH" = (
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/whitegreen{
 	dir = 9
 	},
@@ -16842,7 +16572,6 @@
 /area/prison/recreation/staff)
 "bat" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
 	},
@@ -17259,13 +16988,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/prison/residential/central)
-"bbN" = (
-/obj/machinery/air_alarm,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/blue{
-	dir = 1
-	},
-/area/prison/cellblock/vip)
 "bbO" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -17626,7 +17348,6 @@
 	},
 /area/prison/cellblock/lowsec/ne)
 "bdh" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/blue/full,
 /area/prison/storage/vip)
@@ -18173,9 +17894,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "beJ" = (
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/blue,
 /area/prison/cellblock/vip)
@@ -18436,20 +18154,8 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
-"bfF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/plate,
-/area/prison/toilet/canteen)
 "bfG" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -18550,9 +18256,6 @@
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
 "bfQ" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/prison/hallway/entrance)
@@ -18818,9 +18521,6 @@
 /area/prison/cellblock/vip)
 "bgH" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -19775,12 +19475,6 @@
 	dir = 6
 	},
 /area/prison/cellblock/lowsec/ne)
-"bjq" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/cellstripe{
-	dir = 8
-	},
-/area/prison/security/monitoring/highsec)
 "bjr" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -19992,10 +19686,6 @@
 	dir = 1
 	},
 /area/prison/security/monitoring/highsec)
-"bjU" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/holding/holding1)
 "bjV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -20003,10 +19693,6 @@
 	dir = 10
 	},
 /area/prison/security/monitoring/highsec)
-"bjW" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/visitation)
 "bjX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -20347,7 +20033,6 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/highsec)
 "bkZ" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/visitation)
@@ -20607,9 +20292,6 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/se)
 "blR" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 8
@@ -21172,9 +20854,6 @@
 	},
 /area/prison/security/monitoring/highsec)
 "bnU" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
@@ -21704,9 +21383,6 @@
 /area/prison/hangar/main)
 "bpb" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -21808,7 +21484,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/red/full,
 /area/prison/security/checkpoint/highsec/s)
 "bpu" = (
@@ -21893,13 +21568,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
-"bpN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/hallway/central)
 "bpQ" = (
 /obj/item/ammo_casing,
 /obj/effect/decal/cleanable/blood,
@@ -21940,9 +21608,6 @@
 /turf/open/floor/prison/plate,
 /area/prison/toilet/canteen)
 "bpV" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -21989,7 +21654,6 @@
 /area/prison/security/monitoring/highsec)
 "bqf" = (
 /obj/structure/flora/pottedplant,
-/obj/machinery/air_alarm,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
@@ -22427,13 +22091,6 @@
 /area/prison/monorail/west)
 "brA" = (
 /obj/machinery/vending/cola,
-/turf/open/floor/prison/green/full,
-/area/prison/monorail/west)
-"brB" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/green/full,
 /area/prison/monorail/west)
 "brC" = (
@@ -23202,9 +22859,6 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/visitation)
 "bun" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
@@ -23302,7 +22956,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/green{
 	dir = 1
@@ -23688,9 +23341,6 @@
 	},
 /area/prison/security/checkpoint/medsec)
 "bvR" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -24344,17 +23994,6 @@
 	dir = 1
 	},
 /area/prison/hallway/entrance)
-"byj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/sw)
 "byl" = (
 /obj/machinery/light,
 /turf/open/floor/prison,
@@ -24369,17 +24008,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/green/full,
 /area/prison/monorail/west)
-"byp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/se)
 "byq" = (
 /obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/green/full,
@@ -24507,19 +24135,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
-"byN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/obj/structure/cable,
-/turf/open/floor/prison/green{
-	dir = 1
-	},
-/area/prison/cellblock/lowsec/sw)
 "byO" = (
 /obj/structure/toilet{
 	dir = 4
@@ -24564,19 +24179,6 @@
 /obj/structure/toilet,
 /turf/open/floor/prison/kitchen,
 /area/prison/holding/holding1)
-"byV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/green{
-	dir = 1
-	},
-/area/prison/cellblock/lowsec/se)
 "byW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison/bright_clean,
@@ -24793,13 +24395,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/south/north)
-"bzM" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
-/turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/se)
 "bzN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light{
@@ -24877,12 +24472,6 @@
 	dir = 6
 	},
 /area/prison/cellblock/lowsec/se)
-"bAd" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/south/north)
 "bAe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -25074,7 +24663,6 @@
 	},
 /area/prison/hangar/main)
 "bAM" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/red{
@@ -25089,10 +24677,6 @@
 	},
 /turf/open/space/sea,
 /area/space)
-"bAQ" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean,
-/area/prison/holding/holding2)
 "bAR" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -25211,9 +24795,6 @@
 /area/prison/cellblock/lowsec/sw)
 "bBj" = (
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 10
@@ -25370,12 +24951,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
-"bBK" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkbrown{
-	dir = 5
-	},
-/area/prison/hallway/east)
 "bBL" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25469,13 +25044,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/full,
 /area/prison/security/checkpoint/highsec/s)
-"bCj" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/prison/quarters/security)
 "bCk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25766,9 +25334,6 @@
 /area/prison/hangar/main)
 "bDo" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -25782,15 +25347,11 @@
 /area/prison/maintenance/residential/se)
 "bDr" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/darkbrown{
 	dir = 8
 	},
 /area/prison/hallway/east)
 "bDs" = (
-/obj/machinery/air_alarm,
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
@@ -25830,7 +25391,6 @@
 	},
 /area/prison/cellblock/lowsec/sw)
 "bDy" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
@@ -26057,7 +25617,6 @@
 	},
 /area/prison/cellblock/lowsec/se)
 "bEe" = (
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/darkbrown{
 	dir = 5
 	},
@@ -26074,10 +25633,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/lowsec/se)
-"bEg" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/residential/south)
 "bEh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -26498,7 +26053,6 @@
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/se)
 "bFz" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
@@ -26527,9 +26081,6 @@
 /area/prison/hallway/central)
 "bFE" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/prison/parole/main)
 "bFF" = (
@@ -26911,7 +26462,6 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bGN" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/red{
 	dir = 1
@@ -26921,11 +26471,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"bGP" = (
-/obj/machinery/air_alarm,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/bright_clean,
-/area/prison/laundry)
 "bGQ" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
@@ -27041,10 +26586,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
-"bHl" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison,
-/area/prison/storage/medsec)
 "bHm" = (
 /obj/machinery/light{
 	dir = 1
@@ -27062,11 +26603,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
-"bHo" = (
-/obj/machinery/air_alarm,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/engineering)
 "bHp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27175,9 +26711,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/lowsec/se)
 "bHI" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow{
 	dir = 8
@@ -27262,13 +26795,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/prison/maintenance/hangar_barracks)
-"bIc" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bId" = (
@@ -27624,11 +27150,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/se)
-"bIW" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/wood,
-/area/prison/library)
 "bIX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -27673,10 +27194,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/parole/main)
-"bJh" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/wood,
-/area/prison/library)
 "bJi" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
@@ -27697,10 +27214,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
-"bJn" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/engineering/atmos)
 "bJo" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -27863,9 +27376,6 @@
 /area/prison/holding/holding2)
 "bJU" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/toilet/security)
 "bJV" = (
@@ -28081,13 +27591,6 @@
 /obj/structure/bed/chair,
 /turf/open/floor/wood,
 /area/prison/parole/main)
-"bKG" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/prison/bright_clean,
-/area/prison/laundry)
 "bKI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -28459,10 +27962,6 @@
 	dir = 1
 	},
 /area/prison/storage/highsec/s)
-"bLV" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/access/south)
 "bLW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28646,13 +28145,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/south)
-"bME" = (
-/obj/structure/bed/chair,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/south/north)
 "bMF" = (
 /turf/open/floor/prison,
 /area/prison/storage/highsec/s)
@@ -28741,7 +28233,6 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
 "bMP" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
@@ -28809,7 +28300,6 @@
 	},
 /area/prison/intake)
 "bNc" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow/full,
@@ -28989,20 +28479,6 @@
 /obj/structure/toilet,
 /turf/open/floor/prison/kitchen,
 /area/prison/holding/holding2)
-"bNH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/yellow/full,
-/area/prison/security/checkpoint/medsec)
 "bNI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -29183,11 +28659,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
-"bOe" = (
-/obj/machinery/air_alarm,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/blue/full,
-/area/prison/cellblock/protective)
 "bOf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -29368,9 +28839,6 @@
 /area/prison/parole/main)
 "bOM" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -29750,9 +29218,6 @@
 /area/prison/engineering)
 "bQg" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/prison/engineering/atmos)
 "bQi" = (
@@ -30010,12 +29475,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
-"bRc" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/yellow{
-	dir = 1
-	},
-/area/prison/cellblock/mediumsec/north)
 "bRd" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -30157,7 +29616,6 @@
 /area/prison/residential/central)
 "bRE" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -30247,12 +29705,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/security)
-"bSa" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
-	},
-/area/prison/hallway/engineering)
 "bSb" = (
 /obj/machinery/vending/nanomed{
 	dir = 1
@@ -30478,9 +29930,6 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
 "bSH" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/yellow{
 	dir = 8
@@ -30733,13 +30182,9 @@
 /area/prison/residential/south)
 "bTF" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/prison,
 /area/prison/recreation/medsec)
 "bTH" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/security/head)
@@ -31248,9 +30693,6 @@
 /area/prison/cellblock/highsec/south/north)
 "bVB" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
 	dir = 10
@@ -31422,7 +30864,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/engineering)
 "bWd" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/blue{
 	dir = 9
@@ -31475,7 +30916,6 @@
 	},
 /area/prison/intake)
 "bWv" = (
-/obj/machinery/air_alarm,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison,
@@ -31577,15 +31017,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
-"bWO" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred{
-	dir = 1
-	},
-/area/prison/security/briefing)
 "bWP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -31876,12 +31307,6 @@
 	dir = 4
 	},
 /area/prison/hallway/east)
-"bXR" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkred{
-	dir = 1
-	},
-/area/prison/security/briefing)
 "bXS" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred,
@@ -32244,10 +31669,6 @@
 	dir = 8
 	},
 /area/prison/engineering/atmos)
-"bZa" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/wood,
-/area/prison/parole/protective_custody)
 "bZb" = (
 /turf/open/floor/prison/darkyellow{
 	dir = 4
@@ -32699,17 +32120,7 @@
 	dir = 1
 	},
 /area/prison/security)
-"caJ" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/prison/disposal)
 "caK" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/execution)
@@ -32902,9 +32313,6 @@
 /area/prison/security)
 "cbt" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/weed_node,
@@ -33043,9 +32451,6 @@
 /area/prison/hallway/engineering)
 "cbQ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/weed_node,
@@ -33468,10 +32873,6 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
-"ccY" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/pirate)
 "ccZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33828,9 +33229,6 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cdP" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/red{
 	dir = 8
@@ -33845,12 +33243,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
-"cdT" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/blue{
-	dir = 1
-	},
-/area/prison/cellblock/protective)
 "cdU" = (
 /obj/structure/cable,
 /turf/open/floor/prison/yellow{
@@ -33889,9 +33281,6 @@
 	},
 /area/prison/hallway/central)
 "cdZ" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 9
@@ -33947,9 +33336,6 @@
 /area/prison/cellblock/mediumsec/north)
 "ceg" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec_medsec)
 "ceh" = (
@@ -34063,13 +33449,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
-"ceB" = (
-/obj/machinery/conveyor{
-	dir = 8
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/plating,
-/area/prison/disposal)
 "ceC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -34591,11 +33970,6 @@
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/south)
-"cgp" = (
-/obj/structure/bed,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/blackfloor,
-/area/prison/pirate)
 "cgr" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/plate,
@@ -35052,13 +34426,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
-"chS" = (
-/obj/structure/bed/chair,
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/yellow{
-	dir = 1
-	},
-/area/prison/cellblock/mediumsec/north)
 "chT" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
@@ -35096,9 +34463,6 @@
 /area/prison/security/briefing)
 "chX" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/west)
 "chY" = (
@@ -35115,9 +34479,6 @@
 /area/prison/security/armory/riot)
 "chZ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/east)
 "cia" = (
@@ -35416,7 +34777,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/air_alarm,
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cjd" = (
@@ -35688,9 +35048,6 @@
 /turf/open/floor/prison,
 /area/prison/execution)
 "cjX" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 4
@@ -35721,7 +35078,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
-/obj/machinery/air_alarm,
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -35742,7 +35098,6 @@
 /turf/open/floor/wood,
 /area/prison/security/head)
 "cki" = (
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/yellow{
 	dir = 1
@@ -35762,9 +35117,6 @@
 /area/prison/pirate)
 "cko" = (
 /obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/machinery/power/apc/drained{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -44288,11 +43640,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/prison/residential/south)
-"kYv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
-/turf/open/floor/wood,
-/area/prison/parole/protective_custody)
 "kZq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44882,10 +44229,6 @@
 	dir = 8
 	},
 /area/prison/cellblock/lowsec/nw)
-"muY" = (
-/obj/machinery/air_alarm,
-/turf/open/floor/wood/broken,
-/area/prison/parole/main)
 "mvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45172,17 +44515,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/south)
-"mSo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/air_alarm,
-/turf/open/floor/prison/darkred/full,
-/area/prison/security/checkpoint/maxsec)
 "mTC" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/plating,
@@ -45210,7 +44542,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
@@ -45235,13 +44566,6 @@
 "mYx" = (
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
-"mYC" = (
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/prison/engineering)
 "mYM" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -47685,9 +47009,6 @@
 /turf/open/floor/prison,
 /area/prison/execution)
 "rGJ" = (
-/obj/machinery/power/apc/drained{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -50424,9 +49745,6 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "xly" = (
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 8
@@ -57256,7 +56574,7 @@ gbA
 tvZ
 cTQ
 cOd
-byj
+bBJ
 bxf
 cCM
 iJd
@@ -57733,7 +57051,7 @@ aRT
 aRT
 aRT
 aRT
-aOf
+aSN
 aSN
 jfO
 aRT
@@ -61122,7 +60440,7 @@ mLi
 bKo
 bKo
 bGU
-bEg
+mYx
 bPc
 bQK
 bGQ
@@ -61320,7 +60638,7 @@ avl
 avl
 avl
 avl
-aDr
+aBV
 aIw
 aBU
 aAN
@@ -61830,7 +61148,7 @@ axG
 axG
 axG
 avN
-axp
+aDI
 aDI
 aBV
 aBV
@@ -63167,7 +62485,7 @@ hQI
 hQI
 hQI
 bzv
-byp
+bxy
 bzu
 bxN
 aab
@@ -63388,7 +62706,7 @@ aaq
 aaq
 aaq
 aRU
-aOo
+fLv
 uNd
 aDc
 iqK
@@ -63953,7 +63271,7 @@ bGU
 bVu
 bGU
 bSj
-bLV
+oxt
 nQc
 oxt
 oxt
@@ -64964,7 +64282,7 @@ bsk
 bta
 byo
 bzw
-brB
+bzw
 bsl
 bsl
 bsm
@@ -67996,7 +67314,7 @@ aab
 adO
 aab
 axI
-awT
+biv
 aAW
 api
 qqY
@@ -68029,7 +67347,7 @@ beS
 bgs
 bqJ
 baa
-aYx
+bjR
 bhB
 aXK
 aXK
@@ -68295,7 +67613,7 @@ lnA
 bhB
 oie
 baa
-bjq
+bsp
 bsp
 hyp
 bsp
@@ -68838,7 +68156,7 @@ aab
 adO
 aab
 bSk
-bLV
+oxt
 bWH
 bZG
 bSk
@@ -71336,7 +70654,7 @@ apk
 apk
 aoo
 aor
-awC
+wmU
 aAe
 aox
 aGb
@@ -71406,7 +70724,7 @@ bvA
 bwD
 bLc
 bvA
-bME
+bTT
 bKs
 bwA
 bZQ
@@ -72704,7 +72022,7 @@ spw
 chg
 cio
 cio
-ccY
+lZe
 nuD
 lZe
 lZe
@@ -72971,7 +72289,7 @@ lZe
 lZe
 cqz
 cio
-cgp
+crO
 cmF
 sHD
 ctE
@@ -73496,7 +72814,7 @@ ctG
 swi
 pyA
 cio
-ccY
+lZe
 lZe
 lZe
 cxF
@@ -74948,7 +74266,7 @@ cyz
 aEQ
 kTn
 aCl
-aJu
+ibS
 aDS
 aPc
 fUv
@@ -75506,7 +74824,7 @@ bCf
 snZ
 bvG
 bvA
-bAd
+byC
 bGf
 ovE
 bxm
@@ -75998,7 +75316,7 @@ bfc
 bfc
 bfc
 bfc
-bbN
+woO
 niT
 boa
 beJ
@@ -78528,7 +77846,7 @@ akK
 xhO
 xhO
 akK
-atD
+fYc
 akV
 axM
 ayz
@@ -79559,7 +78877,7 @@ akK
 fYc
 adz
 axM
-auv
+ayD
 eWS
 ayD
 ayD
@@ -80047,7 +79365,7 @@ aiO
 aje
 aem
 add
-acL
+gxX
 rKg
 gxX
 akF
@@ -81309,7 +80627,7 @@ bWl
 bWl
 bWl
 acK
-acL
+gxX
 sQS
 gxX
 add
@@ -82101,7 +81419,7 @@ aiP
 aiP
 aiP
 add
-ajw
+ajN
 akj
 ajN
 acS
@@ -82676,7 +81994,7 @@ aNp
 nEb
 aZI
 jNw
-aIH
+vSz
 bRS
 beB
 aKO
@@ -82711,9 +82029,9 @@ bnE
 swF
 qpI
 bOq
-bGP
+dMY
 bRb
-bKG
+bRb
 dMY
 myF
 myF
@@ -82911,7 +82229,7 @@ axM
 axM
 axM
 axM
-aIH
+vSz
 swF
 bRS
 vSz
@@ -83154,7 +82472,7 @@ akK
 xhO
 xhO
 akK
-mSo
+vJh
 axj
 aBZ
 jYZ
@@ -83430,7 +82748,7 @@ aFE
 alo
 vSz
 jNw
-aKC
+aNT
 aPx
 aBY
 aSd
@@ -83991,7 +83309,7 @@ bHC
 bxP
 bsG
 lAp
-aIH
+vSz
 bRS
 swF
 vSz
@@ -84189,7 +83507,7 @@ azZ
 jYZ
 hKi
 jYZ
-axY
+aCO
 aCW
 aCW
 aGx
@@ -84258,7 +83576,7 @@ bPE
 bPE
 bPz
 bPz
-bNH
+bSW
 bXe
 mBH
 xyg
@@ -84736,7 +84054,7 @@ pwT
 aUn
 bkp
 aNp
-aXY
+eOr
 eOr
 jWH
 eOr
@@ -85269,7 +84587,7 @@ bql
 bql
 bql
 bql
-byN
+iGL
 bFm
 bql
 bql
@@ -85308,7 +84626,7 @@ ccV
 ccV
 ccV
 ccV
-chS
+csH
 cvA
 cvA
 ctT
@@ -85444,7 +84762,7 @@ adB
 ajm
 akq
 add
-acL
+gxX
 sQS
 akK
 ayM
@@ -87337,7 +86655,7 @@ bRS
 swF
 vSz
 bPL
-bHl
+tZs
 tZs
 tZs
 tZs
@@ -87601,7 +86919,7 @@ bUx
 bVO
 bPM
 bPL
-bRc
+mBH
 xyg
 ccV
 ceb
@@ -88843,7 +88161,7 @@ bcm
 eOr
 bdE
 bfw
-aXY
+eOr
 bib
 qNF
 eOr
@@ -89028,7 +88346,7 @@ kVy
 svM
 svM
 afP
-age
+agf
 agt
 agt
 agt
@@ -89384,7 +88702,7 @@ bqs
 bDX
 bFt
 myW
-aIH
+vSz
 bRS
 pDV
 aKS
@@ -89650,7 +88968,7 @@ bRS
 swF
 vSz
 bPL
-bHl
+tZs
 tZs
 inh
 tZs
@@ -90169,7 +89487,7 @@ tZs
 bSZ
 bPM
 bPL
-bOe
+xOW
 bYK
 bYK
 bYK
@@ -90924,7 +90242,7 @@ bqs
 bqs
 bqs
 bEd
-bzM
+bAa
 bqs
 bqs
 bqs
@@ -91130,7 +90448,7 @@ aAp
 aBw
 aDj
 apK
-azF
+aFC
 aGC
 mtd
 aJe
@@ -91694,7 +91012,7 @@ bqs
 bqs
 bqs
 bqs
-byV
+bDZ
 bFA
 bqs
 bqs
@@ -92189,7 +91507,7 @@ aYk
 aPE
 bkx
 aNq
-aXY
+eOr
 eOr
 jWH
 eOr
@@ -92221,7 +91539,7 @@ bAB
 bND
 bPX
 bPZ
-bIW
+bRx
 okw
 bUC
 okw
@@ -92367,7 +91685,7 @@ aab
 aab
 aab
 aeZ
-acP
+afm
 veP
 agk
 agq
@@ -92385,7 +91703,7 @@ akc
 akA
 aiI
 alf
-ajE
+gaZ
 gaZ
 gaZ
 gaZ
@@ -92642,7 +91960,7 @@ akd
 akB
 akP
 alg
-ajM
+alM
 alM
 alM
 alM
@@ -92657,7 +91975,7 @@ awS
 aGS
 asy
 atf
-apg
+auh
 auh
 hqG
 hqG
@@ -92894,7 +92212,7 @@ agq
 aiu
 afv
 aiI
-aiw
+ajD
 kRr
 sOM
 aka
@@ -92986,7 +92304,7 @@ bHH
 bCD
 bGv
 myW
-aIH
+vSz
 bRS
 bBg
 aKO
@@ -93167,7 +92485,7 @@ aoS
 gaZ
 apY
 alf
-atI
+awS
 mZj
 asz
 atf
@@ -93249,7 +92567,7 @@ swF
 vSz
 sXO
 bPZ
-bJh
+okw
 okw
 okw
 bVU
@@ -93962,7 +93280,7 @@ aGT
 aIe
 aJh
 aAv
-aIH
+vSz
 upB
 bRS
 vSz
@@ -94241,7 +93559,7 @@ aNq
 aOe
 baR
 gWy
-aIH
+vSz
 alo
 iTP
 pTN
@@ -94719,7 +94037,7 @@ dDo
 auY
 avB
 avB
-atI
+awS
 jEE
 mmP
 ayZ
@@ -94775,7 +94093,7 @@ vSz
 vSz
 vSz
 vSz
-bpN
+aNt
 aXa
 vSz
 vSz
@@ -95063,7 +94381,7 @@ cgz
 bXj
 chz
 bQi
-cdT
+bXv
 tQo
 cht
 cht
@@ -95304,7 +94622,7 @@ pTN
 nQX
 vSz
 bQi
-bHo
+ycx
 ycx
 ldL
 ycx
@@ -97111,7 +96429,7 @@ ycx
 bRC
 bYX
 caA
-mYC
+bUF
 ccn
 cbJ
 cft
@@ -97338,7 +96656,7 @@ aXd
 aYu
 qFw
 aTF
-bjU
+dtT
 ggC
 kpA
 bwT
@@ -97352,7 +96670,7 @@ bEA
 mCn
 oAY
 bHJ
-bAQ
+bIZ
 bIZ
 bKD
 bJq
@@ -97639,7 +96957,7 @@ clr
 cjL
 kXo
 chH
-ceB
+cps
 cqk
 cqW
 suU
@@ -97815,7 +97133,7 @@ aDy
 aDy
 aDy
 aDy
-aGY
+fIb
 aKi
 blK
 aLH
@@ -97888,7 +97206,7 @@ ejP
 cfw
 cgF
 chH
-bZa
+ciU
 cjL
 cjL
 qKJ
@@ -98145,7 +97463,7 @@ cbW
 cfw
 cgF
 chH
-kYv
+bZK
 cjM
 ciU
 cjM
@@ -98910,7 +98228,7 @@ bWk
 bXE
 jpX
 bRM
-bSa
+cbS
 hQE
 cbW
 cfw
@@ -100201,7 +99519,7 @@ cbW
 cfw
 cgI
 chN
-caJ
+cjb
 cjR
 ckQ
 clP
@@ -100436,7 +99754,7 @@ bEA
 mCn
 oAY
 bHM
-muY
+sOW
 ktL
 ktL
 bLq
@@ -100702,7 +100020,7 @@ bLn
 bMv
 sOW
 bQj
-bJn
+bWk
 bWk
 bWk
 bWm
@@ -101183,7 +100501,7 @@ bhf
 biw
 bfZ
 bdl
-aYG
+xrI
 aVT
 aXd
 aYu
@@ -102749,7 +102067,7 @@ cFx
 cFx
 dFf
 bBB
-bBK
+bCV
 mCn
 hYR
 bLs
@@ -102986,7 +102304,7 @@ bdl
 bmH
 bmH
 bmH
-bfF
+bpL
 qEG
 bmH
 bmH
@@ -103284,7 +102602,7 @@ qZb
 cev
 bQp
 cgN
-bWO
+chT
 cjd
 cjY
 cjY
@@ -103506,7 +102824,7 @@ bmH
 bmH
 bmH
 btt
-bjW
+bul
 vLM
 bwc
 btt
@@ -104760,7 +104078,7 @@ aIo
 aIo
 aMy
 aHh
-aKg
+aNz
 rUP
 aQk
 aRz
@@ -105597,7 +104915,7 @@ cdC
 bMq
 bZp
 cgN
-bXR
+chW
 cje
 cjY
 cjY
@@ -105801,7 +105119,7 @@ aYB
 aZD
 bav
 bby
-aTp
+urN
 bcA
 bdK
 bcA
@@ -107118,7 +106436,7 @@ bAC
 bFL
 bAC
 bAC
-bCj
+bJo
 bAC
 bKL
 bLw
@@ -108110,7 +107428,7 @@ aON
 aON
 aON
 aXp
-aTg
+uEg
 yiK
 iMr
 baB
@@ -109401,7 +108719,7 @@ aYL
 aYL
 aYL
 aYL
-aVm
+eJX
 bnQ
 oRe
 gxT
@@ -110459,7 +109777,7 @@ gsU
 bzn
 ghl
 bGO
-bIc
+foA
 bIe
 hUJ
 ics


### PR DESCRIPTION
## `Основные изменения`
Как показали тесты, лаги на Призонке вызваны обилием(200+) алярмов и АПЦ на карте. Я убрал их количество, оставив по 1-2(если большие зоны) на зону

## `Как это улучшит игру`
Меньше лагов на карте

## `Ченджлог`
```
:cl:
map: Количество АПЦ и алярмов на Призонке уменьшего
/:cl:
```
