### PR TITLE
Mobs no longer bounce off walls

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -55,6 +55,8 @@
 #define SHUTTLE_IMMUNE (1<<14)
 /// Should we use the initial icon for display? Mostly used by overlay only objects
 #define HTML_USE_INITAL_ICON_1 (1<<15)
+/// This atom should not bounce
+#define NO_BOUNCE (1<<16)
 
 //==========================================================================================
 

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -481,7 +481,7 @@ RU TGMC EDIT */
 	hit_successful = hit_atom.hitby(src, speed)
 	if(hit_successful)
 		SEND_SIGNAL(src, COMSIG_MOVABLE_IMPACT, hit_atom, speed)
-		if(bounce && hit_atom.density && !isliving(hit_atom))
+		if(bounce && hit_atom.density && !isliving(hit_atom) && !(flags_atom & NO_BOUNCE))
 			INVOKE_NEXT_TICK(src, PROC_REF(throw_bounce), hit_atom, old_throw_source)
 	return hit_successful //if the throw missed, it continues
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,6 +1,6 @@
 /mob/living
 	see_invisible = SEE_INVISIBLE_LIVING
-	flags_atom = CRITICAL_ATOM|PREVENT_CONTENTS_EXPLOSION|BUMP_ATTACKABLE
+	flags_atom = CRITICAL_ATOM|PREVENT_CONTENTS_EXPLOSION|BUMP_ATTACKABLE|NO_BOUNCE
 	///0 for no override, sets see_invisible = see_override in silicon & carbon life process via update_sight()
 	var/see_override = 0
 	///Badminnery resize


### PR DESCRIPTION
## `Основные изменения`

Мобы больше не отскакивают когда врезаются в стену. Урон все так же наносится

## `Как это улучшит игру`

Ничего интересного в игру этот механ не добавил, кроме раздражения. Паунсами/джетпаком просто невозможно пользоваться в зданиях или в застройке.

## `Ченджлог`
```
:cl:
add: Мобы больше не отскакивают когда врезаются в стену.
/:cl:
```
