### PR TITLE
Xeno upgrades nerf

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -34,6 +34,7 @@
 #define DEFILER_TRANSVITOX "Transvitox"
 #define DEFILER_OZELOMELYN "Ozelomelyn"
 #define DEFILER_ACID "Sulphuric acid"
+#define DEFILER_SANGUINAL "Sanguinal"
 
 //Panther tearing tail reagents
 #define PANTHER_HEMODILE "Hemodile"

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -1067,10 +1067,14 @@
 
 /datum/status_effect/upgrade_vampirism/proc/on_slash(datum/source, mob/living/target)
 	SIGNAL_HANDLER
-	if(target.stat == DEAD || !ishuman(target))
+	if(target.stat == DEAD)
 		return
-	var/health_amount = buff_owner.maxHealth * leech_buff_per_chamber * chamber_scaling
-	HEAL_XENO_DAMAGE(buff_owner, health_amount, FALSE)
+	if(!ishuman(target))
+		return
+	var/bruteloss_healed = buff_owner.maxHealth * leech_buff_per_chamber * chamber_scaling
+	var/fireloss_healed = clamp(bruteloss_healed - buff_owner.bruteloss, 0, bruteloss_healed)
+	buff_owner.adjustBruteLoss(-bruteloss_healed)
+	buff_owner.adjustFireLoss(-fireloss_healed)
 	buff_owner.updatehealth()
 
 // ***************************************

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -973,7 +973,7 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/upgrade_carapace
 	var/mob/living/carbon/xenomorph/buff_owner
-	var/armor_buff_per_chamber = 5
+	var/armor_buff_per_chamber = 2.5
 	var/chamber_scaling = 0
 
 /datum/status_effect/upgrade_carapace/on_apply()
@@ -1010,8 +1010,8 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/upgrade_regeneration
 	var/mob/living/carbon/xenomorph/buff_owner
-	var/regen_buff_per_chamber = 0.05
-	var/sunder_regen_per_chamber = 0.33
+	var/regen_buff_per_chamber = 0.008
+	var/sunder_regen_per_chamber = 0.166
 	var/chamber_scaling = 0
 
 /datum/status_effect/upgrade_regeneration/on_apply()
@@ -1044,7 +1044,7 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/upgrade_vampirism
 	var/mob/living/carbon/xenomorph/buff_owner
-	var/leech_buff_per_chamber = 0.033
+	var/leech_buff_per_chamber = 0.016
 	var/chamber_scaling = 0
 
 /datum/status_effect/upgrade_vampirism/on_apply()
@@ -1067,14 +1067,10 @@
 
 /datum/status_effect/upgrade_vampirism/proc/on_slash(datum/source, mob/living/target)
 	SIGNAL_HANDLER
-	if(target.stat == DEAD)
+	if(target.stat == DEAD || !ishuman(target))
 		return
-	if(!ishuman(target))
-		return
-	var/bruteloss_healed = buff_owner.maxHealth * leech_buff_per_chamber * chamber_scaling
-	var/fireloss_healed = clamp(bruteloss_healed - buff_owner.bruteloss, 0, bruteloss_healed)
-	buff_owner.adjustBruteLoss(-bruteloss_healed)
-	buff_owner.adjustFireLoss(-fireloss_healed)
+	var/health_amount = buff_owner.maxHealth * leech_buff_per_chamber * chamber_scaling
+	HEAL_XENO_DAMAGE(buff_owner, health_amount, FALSE)
 	buff_owner.updatehealth()
 
 // ***************************************
@@ -1199,7 +1195,7 @@
 			DEFILER_OZELOMELYN = image('icons/Xeno/actions.dmi', icon_state = DEFILER_OZELOMELYN),
 			DEFILER_HEMODILE = image('icons/Xeno/actions.dmi', icon_state = DEFILER_HEMODILE),
 			DEFILER_TRANSVITOX = image('icons/Xeno/actions.dmi', icon_state = DEFILER_TRANSVITOX),
-			DEFILER_NEUROTOXIN = image('icons/Xeno/actions.dmi', icon_state = DEFILER_NEUROTOXIN),
+			DEFILER_SANGUINAL = image('icons/Xeno/actions.dmi', icon_state = DEFILER_SANGUINAL),
 			DEFILER_ACID = image('icons/Xeno/actions.dmi', icon_state = DEFILER_ACID),
 		)
 	var/datum/status_effect/upgrade_toxin/effect = attached_effect
@@ -1224,12 +1220,12 @@
 	var/mob/living/carbon/xenomorph/buff_owner
 	var/toxin_amount_per_chamber = 1
 	var/chamber_scaling = 0
-	var/datum/reagent/toxin/injected_reagent = /datum/reagent/toxin/xeno_neurotoxin
+	var/datum/reagent/toxin/injected_reagent = /datum/reagent/toxin/xeno_transvitox
 	var/list/selectable_reagents = list(
 		/datum/reagent/toxin/xeno_ozelomelyn,
 		/datum/reagent/toxin/xeno_hemodile,
 		/datum/reagent/toxin/xeno_transvitox,
-		/datum/reagent/toxin/xeno_neurotoxin,
+		/datum/reagent/toxin/xeno_sanguinal,
 		/datum/reagent/toxin/acid,
 	)
 
@@ -1290,7 +1286,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/upgrade_pheromones
 	var/mob/living/carbon/xenomorph/buff_owner
 	var/datum/aura_bearer/current_aura
-	var/phero_power_per_chamber = 1
+	var/phero_power_per_chamber = 0.5
 	var/phero_power_base = 1
 	var/chamber_scaling = 0
 	var/emitted_aura = AURA_XENO_RECOVERY
@@ -1348,7 +1344,7 @@
 	var/chamber_scaling = 0
 	var/list/selectable_trails = list(
 		/obj/effect/xenomorph/spray,
-		/obj/alien/resin/sticky/thin,
+		/obj/alien/resin/sticky/thin/temporary,
 	)
 
 /datum/status_effect/upgrade_trail/on_apply()

--- a/code/game/objects/structures/xeno/resin.dm
+++ b/code/game/objects/structures/xeno/resin.dm
@@ -80,3 +80,7 @@
 
 	ignore_weed_destruction = FALSE
 	refundable = FALSE
+
+/obj/alien/resin/sticky/thin/temporary/Initialize(mapload)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(obj_destruction), MELEE), 3 SECONDS)


### PR DESCRIPTION
## `Основные изменения`

Нерф некоторых апгрейдов. Липкая резина теперь исчезает со временем. Нейротоксин заменен на сангвинал.

## `Как это улучшит игру`

БАЛАНС

## `Ченджлог`
```
:cl:
add: Липкая резина исчезает со временем.
add: Нейротоксин заменен на сангвинал
balance: Армор теперь увеличивается только на 2.5 за чамбер вместо 5.
balance: Реген за чамбер 0.05 -> 0.008. Сандер 0.33 -> 0.166
balance: Вампиризм за чамбер 0.033 -> 0.016
balance: Сила фер за чамбер 1 -> 0.5

/:cl:
```
