### PR TITLE
Nerf MK88

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/pistol.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/pistol.dm
@@ -93,6 +93,8 @@
 	shrapnel_chance = 0
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY
 	damage = 20
+	penetration = 0
+	additional_xeno_penetration = 0
 
 /datum/ammo/bullet/pistol/squash
 	name = "squash-head pistol bullet"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -531,7 +531,6 @@
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/flashlight/under,
-		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/lace,
 	)
 


### PR DESCRIPTION
## `Основные изменения`
Нерф МК88 из гиб-пушки.
Убрал БурстАсембли.
Убрал пенетру у зажигалок.

## `Как это улучшит игру`

## `Ченджлог`

```
:cl:
balance: Удалил Пенетру у зажигалок и БурстАсембли у МК88
balance: АП зажигалок на пистолет 25 -> 0
/:cl:
```

