### PR TITLE
Фаллов Вектор 3 >> 1.75, убрал дубликаты кода allowed_ammo_types

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/submachinegun.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/submachinegun.dm
@@ -27,7 +27,7 @@
 	accuracy_var_high = 7
 	damage = 20
 	accurate_range = 4
-	damage_falloff = 3
+	damage_falloff = 1.75
 	penetration = 0
 	additional_xeno_penetration = 10
 	shrapnel_chance = 25

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -42,7 +42,6 @@
 	max_shells = 36 //codex
 	force = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/ar18
-	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/ar18)
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items_lefthand_1.dmi',
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',
@@ -139,7 +138,6 @@
 	max_shells = 50 //codex
 	force = 20
 	default_ammo_type = /obj/item/ammo_magazine/rifle/ar12
-	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/ar12)
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items_lefthand_1.dmi',
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',
@@ -681,7 +679,6 @@
 	cocked_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/rifle/lmg_d
 	allowed_ammo_types = list(/obj/item/ammo_magazine/rifle/lmg_d)
-
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/bayonetknife,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -49,7 +49,6 @@
 	type_of_casings = null
 	default_ammo_type = /obj/item/ammo_magazine/smg/mp19
 	allowed_ammo_types = list(/obj/item/ammo_magazine/smg/mp19)
-
 	w_class = WEIGHT_CLASS_NORMAL
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,
@@ -422,7 +421,6 @@
 	default_ammo_type = /obj/item/ammo_magazine/smg/uzi
 	allowed_ammo_types = list(/obj/item/ammo_magazine/smg/uzi, /obj/item/ammo_magazine/smg/uzi/extended)
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 27, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
-
 	fire_delay = 0.15 SECONDS
 	burst_amount = 4
 	accuracy_mult_unwielded = 0.9


### PR DESCRIPTION
## `Основные изменения`
1. Фаллоу вектора теперь 1.75
2. Убрал дубли allowed_ammo_types
## `Как это улучшит игру`
Пушка играбельная, в коде меньше насрано говна
## `Ченджлог`
```
:cl:
balance: Фаллоу вектора 3 >> 1.75
code: Убраны дубликаты allowed_ammo_types у АРкок
/:cl:
```