### PR TITLE
Fix tank chair wrench

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -153,7 +153,7 @@
 			new buildstacktype (loc, buildstackamount)
 		qdel(src)
 
-/obj/structure/bed/wrench_act(mob/living/user, obj/item/I)
+/obj/structure/bed/wrench_act()
 	if(resistance_flags & RESIST_ALL)
 		return
 	if(!buildstacktype)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -155,7 +155,8 @@
 
 /obj/structure/bed/attackby(obj/item/I, mob/user, params)
 	. = ..()
-
+	if(resistance_flags && RESIST_ALL)
+		return
 	if(iswrench(I))
 		if(!buildstacktype)
 			return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -154,8 +154,6 @@
 		qdel(src)
 
 /obj/structure/bed/wrench_act(mob/living/user, obj/item/I)
-	if(resistance_flags & RESIST_ALL)
-		return
 	if(!buildstacktype)
 		return
 	playsound(loc, 'sound/items/ratchet.ogg', 25, 1)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -153,20 +153,19 @@
 			new buildstacktype (loc, buildstackamount)
 		qdel(src)
 
+/obj/structure/bed/wrench_act(mob/living/user, obj/item/I)
+	if(resistance_flags & RESIST_ALL)
+		return
+	if(!buildstacktype)
+		return
+	playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+	if(dropmetal)
+		new buildstacktype(loc, buildstackamount)
+	qdel(src)
+
 /obj/structure/bed/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(resistance_flags && RESIST_ALL)
-		return
-	if(iswrench(I))
-		if(!buildstacktype)
-			return
-
-		playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
-		if(dropmetal)
-			new buildstacktype(loc, buildstackamount)
-		qdel(src)
-
-	else if(istype(I, /obj/item/grab) && !LAZYLEN(buckled_mobs) && !buckled_bodybag)
+	if(istype(I, /obj/item/grab) && !LAZYLEN(buckled_mobs) && !buckled_bodybag)
 		var/obj/item/grab/G = I
 		if(!ismob(G.grabbed_thing))
 			return

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -153,7 +153,7 @@
 			new buildstacktype (loc, buildstackamount)
 		qdel(src)
 
-/obj/structure/bed/wrench_act()
+/obj/structure/bed/wrench_act(mob/living/user, obj/item/I)
 	if(resistance_flags & RESIST_ALL)
 		return
 	if(!buildstacktype)

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -4,6 +4,7 @@
 	icon_state = "vehicle_chair"
 	resistance_flags = RESIST_ALL
 	dir = EAST
+	buildstacktype = null
 
 /obj/structure/bed/chair/vehicle_driver_seat
 	name = "driver seat"
@@ -13,6 +14,7 @@
 	dir = EAST
 	///owner of this object, assigned during interior linkage
 	var/obj/vehicle/sealed/armored/owner
+	buildstacktype = null
 
 /obj/structure/bed/chair/vehicle_driver_seat/Destroy()
 	owner = null
@@ -54,6 +56,7 @@
 	dir = EAST
 	///owner of this object, assigned during interior linkage
 	var/obj/vehicle/sealed/armored/owner
+	buildstacktype = null
 
 /obj/structure/bed/chair/vehicle_gunner_seat/link_interior(datum/interior/link)
 	if(!istype(link, /datum/interior/armored))
@@ -91,6 +94,7 @@
 	dir = EAST
 	///owner of this object, assigned during interior linkage
 	var/obj/vehicle/sealed/armored/owner
+	buildstacktype = null
 
 /obj/structure/bed/chair/driver_gunner_seat/link_interior(datum/interior/link)
 	if(!istype(link, /datum/interior/armored))


### PR DESCRIPTION
## `Основные изменения`
Можно было скрутить кресло водителя танка/бтра, из-за чего танк становился бесполезным, добавил иф что бы не убиваемое кресло было также и не скручиваемым
## `Как это улучшит игру`
ноу фанни
## `Ченджлог`
```
:cl:
fix: Танковое кресло не возможно скрутить
/:cl:
```
