### PR TITLE
Storage close fix

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -557,7 +557,7 @@
 				return do_refill(I, user)
 
 	if(!can_be_inserted(I))
-		if(!user.s_active) // if somthing full or you want place too big object, container don't close
+		if(!user.s_active) // Don't close open storage menu if can't insert something, if storage dosen't open it will be open
 			open(user)
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -557,7 +557,8 @@
 				return do_refill(I, user)
 
 	if(!can_be_inserted(I))
-		open(user)
+		if(!user.s_active) // if somthing full or you want place too big object, container don't close
+			open(user)
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)
 


### PR DESCRIPTION
## `Основные изменения`
Рюкзаки не закрываются если предмет слишком большой. 
Люди жаловались что когда воюешь, открываешь патч и хочешь убрать оружие, оружие закидывалось в бэк бэк по ошибке, и это его закрывало, что было очень не удобно, также если положить в переполненое хранилище предмет оно тоже закрывается что ОЧЕНЬ не удобно.
[Discod issue](https://discord.com/channels/1235677154084126861/1304840767788814366)
## `Как это улучшит игру`
## `Ченджлог`
```
:cl:
fix: Теперь если положить слишком большей предмет в хранилище оно не закроется.
/:cl:
```
