### PR TITLE
Old alt+rightclick (take left object from storage)

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -566,7 +566,7 @@
 		open(user)
 
 /obj/item/storage/CtrlShiftClick(mob/living/user) // Take left object in inevtory
-	attempt_draw_object(user,TRUE)
+	attempt_draw_object(user, TRUE)
 
 ///Refills the storage from the refill_types item
 /obj/item/storage/proc/do_refill(obj/item/storage/refiller, mob/user)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -565,6 +565,9 @@
 	if(Adjacent(user) && !isxeno(user))
 		open(user)
 
+/obj/item/storage/CtrlShiftClick(mob/living/user) // Take left object in inevtory
+	attempt_draw_object(user,TRUE)
+
 ///Refills the storage from the refill_types item
 /obj/item/storage/proc/do_refill(obj/item/storage/refiller, mob/user)
 	if(!length(refiller.contents))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -565,7 +565,7 @@
 	if(Adjacent(user) && !isxeno(user))
 		open(user)
 
-/obj/item/storage/CtrlShiftClick(mob/living/user) // Take left object in inevtory
+/obj/item/storage/CtrlShiftClick(mob/living/user) // Take left object in inventory
 	attempt_draw_object(user, TRUE)
 
 ///Refills the storage from the refill_types item


### PR DESCRIPTION
## `Основные изменения`
Раньше на альт клик брал самый левый предмет из инвентаря, сейчас это не так. Некоторым это может сильно пригодится. Теперь можно взять самый левый предмет через ctrl+shift+click. Этот багфикс https://discord.com/channels/1235677154084126861/1303481217626144800
## `Как это улучшит игру`
## `Ченджлог`
```
:cl:
fix: Теперь ctrl+shift+click позволят взять самый левый предмет.
/:cl:
```
