### PR TITLE
Reagent scanner icon fix

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -514,6 +514,11 @@ REAGENT SCANNER
 	var/details = FALSE
 	var/recent_fail = FALSE
 
+/obj/item/reagent_scanner/adv
+	name = "advanced reagent scanner"
+	icon_state = "adv_spectrometer"
+	details = TRUE
+
 /obj/item/reagent_scanner/afterattack(obj/O, mob/user as mob, proximity)
 	if(!proximity)
 		return
@@ -540,8 +545,3 @@ REAGENT SCANNER
 		else
 			recent_fail = TRUE
 	to_chat(user, span_notice("Chemicals found: [dat]"))
-
-/obj/item/reagent_scanner/adv
-	name = "advanced reagent scanner"
-	icon_state = "adv_spectrometer"
-	details = TRUE

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -502,7 +502,7 @@ REAGENT SCANNER
 	name = "reagent scanner"
 	desc = "A hand-held reagent scanner which identifies chemical agents."
 	icon = 'icons/obj/device.dmi'
-	icon_state = "adv_spectrometer"
+	icon_state = "spectrometer"
 	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_atom = CONDUCT

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -501,7 +501,8 @@ REAGENT SCANNER
 /obj/item/reagent_scanner
 	name = "reagent scanner"
 	desc = "A hand-held reagent scanner which identifies chemical agents."
-	icon_state = "spectrometer"
+	icon = "icons/obj/device.dmi"
+	icon_state = "adv_spectrometer"
 	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_atom = CONDUCT

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -501,7 +501,7 @@ REAGENT SCANNER
 /obj/item/reagent_scanner
 	name = "reagent scanner"
 	desc = "A hand-held reagent scanner which identifies chemical agents."
-	icon = "icons/obj/device.dmi"
+	icon = 'icons/obj/device.dmi'
 	icon_state = "adv_spectrometer"
 	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## `Основные изменения`
У реагент сканера все еще не было иконки.
[issue dis](https://discord.com/channels/1235677154084126861/1293833484795641928)
## `Как это улучшит игру`
Использование реагент сканера станет реальным
## `Ченджлог`
```
:cl:
fix: Вернул иконку реагент сканеру
/:cl:
```
