### PR TITLE
Changes RL-160 rocket size.

### DIFF
--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -175,7 +175,7 @@
 	desc = "A high explosive shell for the RL-160 recoilless rifle. Causes a heavy explosion over a small area. Requires specialized storage to carry."
 	caliber = CALIBER_67MM
 	icon_state = "shell"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 1
 	default_ammo = /datum/ammo/rocket/recoilless
 	reload_delay = 30


### PR DESCRIPTION
## `Основные изменения`

Ракеты от РЛки теперь нормального размера, а не булочка

## `Как это улучшит игру`

Теперь они смогут влезать в эксплозив пауч, в который они и ДОЛЖНЫ влезать. Ракеты от садара имеют нормальный размер, по логике и эти ракеты должны иметь нормальный размер. _ксенок*деры чертовы, если скажите что это баланс и заставите переделывать, то Аллах вас не простит!!!_

## `Ченджлог`

```
:cl: MrFloppa
balance: Ракеты для RL-160 теперь normal-sized, вместо bulky
/:cl:
```
