### PR TITLE
Change FK88 ammo cost in factory and add granade launcher ammo

### DIFF
--- a/code/modules/reqs/supplypacks/vehicles.dm
+++ b/code/modules/reqs/supplypacks/vehicles.dm
@@ -31,6 +31,18 @@
 	cost = 10
 	containertype = /obj/structure/closet/crate/ammo
 
+/datum/supply_packs/vehicles/tank_glauncher
+	name = "Tank granade laucnher magazine"
+	contains = list(/obj/item/ammo_magazine/tank/tank_glauncher)
+	cost = 10
+	containertype = /obj/structure/closet/crate/ammo
+
+/datum/supply_packs/vehicles/tank_slauncher
+	name = "Tank granade laucnher smoke magazine"
+	contains = list(/obj/item/ammo_magazine/tank/tank_slauncher)
+	cost = 10
+	containertype = /obj/structure/closet/crate/ammo
+
 /datum/supply_packs/vehicles/motorbike
 	name = "All-Terrain Motorbike"
 	cost = 400

--- a/code/modules/reqs/supplypacks/vehicles.dm
+++ b/code/modules/reqs/supplypacks/vehicles.dm
@@ -32,13 +32,13 @@
 	containertype = /obj/structure/closet/crate/ammo
 
 /datum/supply_packs/vehicles/tank_glauncher
-	name = "Tank granade laucnher magazine"
+	name = "Tank grenade laucnher magazine"
 	contains = list(/obj/item/ammo_magazine/tank/tank_glauncher)
 	cost = 10
 	containertype = /obj/structure/closet/crate/ammo
 
 /datum/supply_packs/vehicles/tank_slauncher
-	name = "Tank granade laucnher smoke magazine"
+	name = "Tank grenade laucnher smoke magazine"
 	contains = list(/obj/item/ammo_magazine/tank/tank_slauncher)
 	cost = 10
 	containertype = /obj/structure/closet/crate/ammo

--- a/code/modules/reqs/supplypacks/vehicles.dm
+++ b/code/modules/reqs/supplypacks/vehicles.dm
@@ -37,12 +37,6 @@
 	cost = 10
 	containertype = /obj/structure/closet/crate/ammo
 
-/datum/supply_packs/vehicles/tank_slauncher
-	name = "Tank grenade laucnher smoke magazine"
-	contains = list(/obj/item/ammo_magazine/tank/tank_slauncher)
-	cost = 10
-	containertype = /obj/structure/closet/crate/ammo
-
 /datum/supply_packs/vehicles/motorbike
 	name = "All-Terrain Motorbike"
 	cost = 400

--- a/code/modules/reqtorio/assembly_crafts.dm
+++ b/code/modules/reqtorio/assembly_crafts.dm
@@ -326,11 +326,6 @@ WEAPONS
 	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
 	output = list(/obj/item/ammo_magazine/tank/tank_glauncher = 1)
 
-/datum/assembly_craft/weapons/gl_smoke_tank_ammo
-	name = "Tank grenade launcher smoke magazine"
-	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
-	output = list(/obj/item/ammo_magazine/tank/tank_slauncher = 1)
-
 /datum/assembly_craft/weapons/heavy_isg_he
 	name = "A 155mm HE shell for the FK-88 mounted flak gun."
 	input = list(/obj/item/stack/sheet/jeweler_steel = 5, /obj/item/stack/gun_powder = 6) // 35 + 48 points

--- a/code/modules/reqtorio/assembly_crafts.dm
+++ b/code/modules/reqtorio/assembly_crafts.dm
@@ -322,12 +322,12 @@ WEAPONS
 	output = list(/obj/item/ammo_magazine/tank/towlauncher = 1)
 
 /datum/assembly_craft/weapons/gl_explosive_tank_ammo
-	name = "Tank grande launcher magazine"
+	name = "Tank grenade launcher magazine"
 	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
 	output = list(/obj/item/ammo_magazine/tank/tank_glauncher = 1)
 
 /datum/assembly_craft/weapons/gl_smoke_tank_ammo
-	name = "Tank grande launcher smoke magazine"
+	name = "Tank grenade launcher smoke magazine"
 	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
 	output = list(/obj/item/ammo_magazine/tank/tank_slauncher = 1)
 

--- a/code/modules/reqtorio/assembly_crafts.dm
+++ b/code/modules/reqtorio/assembly_crafts.dm
@@ -308,25 +308,35 @@ WEAPONS
 
 /datum/assembly_craft/weapons/ltb_shells
 	name = "LTB tank shell"
-	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 5)
+	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 2)
 	output = list(/obj/item/ammo_magazine/tank/ltb_cannon = 1)
 
 /datum/assembly_craft/weapons/ltb_cannon_apfds
 	name = "LTB tank APFDS shell"
-	input = list(/obj/item/stack/sheet/jeweler_steel = 2, /obj/item/stack/gun_powder = 3)
+	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 2)
 	output = list(/obj/item/ammo_magazine/tank/ltb_cannon/apfds = 1)
 
 /datum/assembly_craft/weapons/ltb_cannon_TOW
 	name = "TOW Launcher Magazine"
-	input = list(/obj/item/stack/sheet/jeweler_steel = 3, /obj/item/stack/gun_powder = 6)
+	input = list(/obj/item/stack/sheet/jeweler_steel = 2, /obj/item/stack/gun_powder = 1)
 	output = list(/obj/item/ammo_magazine/tank/towlauncher = 1)
 
+/datum/assembly_craft/weapons/gl_explosive_tank_ammo
+	name = "Tank grande launcher magazine"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
+	output = list(/obj/item/ammo_magazine/tank/tank_glauncher = 1)
+
+/datum/assembly_craft/weapons/gl_smoke_tank_ammo
+	name = "Tank grande launcher smoke magazine"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 1, /obj/item/stack/gun_powder = 1)
+	output = list(/obj/item/ammo_magazine/tank/tank_slauncher = 1)
+
 /datum/assembly_craft/weapons/heavy_isg_he
-	name = "A 15cm HE shell for the FK-88 mounted flak gun."
-	input = list(/obj/item/stack/sheet/jeweler_steel = 25, /obj/item/stack/gun_powder = 30)
-	output = list(/obj/item/ammo_magazine/heavy_isg/he = 1)
+	name = "A 155mm HE shell for the FK-88 mounted flak gun."
+	input = list(/obj/item/stack/sheet/jeweler_steel = 5, /obj/item/stack/gun_powder = 6) // 35 + 48 points
+	output = list(/obj/item/ammo_magazine/heavy_isg/he = 1) // 83 points +-
 
 /datum/assembly_craft/weapons/heavy_isg_sabot
-	name = "A 15cm APFDS shell for the FK-88 mounted flak gun"
-	input = list(/obj/item/stack/sheet/jeweler_steel = 30, /obj/item/stack/gun_powder = 25)
-	output = list(/obj/item/ammo_magazine/heavy_isg/sabot = 1)
+	name = "A 155mm APFDS shell for the FK-88 mounted flak gun"
+	input = list(/obj/item/stack/sheet/jeweler_steel = 5, /obj/item/stack/gun_powder = 7) // 35 + 56 points
+	output = list(/obj/item/ammo_magazine/heavy_isg/sabot = 1) // 91 points +-


### PR DESCRIPTION
## `Основные изменения`
Добавил для granade launcher боезапас в карго и в завод.
Фикс цены на заряды для ФК и танка, так как они стоили 2 раза больше чем в карго, если не больше, например 1 фк заряд стоил БОЛЬШЕ 250 ОЧКОВ, когда в карго он покупался за 100. Также с танковыми снарядами, в карго 10 в заводе 20+
## `Как это улучшит игру`
Завод может стать более полезным по факту.

## `Ченджлог`
```
:cl:
add: Добавил Grenade launcher magazine в завод и карго
balance: Изменил цену боезапаса танка в заводе
balance: Изменил цену боезапаса фк в заводе
/:cl:
```
