### PR TITLE
Кодекс огнестрела 2.0

### DIFF
--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -143,7 +143,7 @@
 				attachments_text["other"] += A.name
 		for(var/i in attachments_text)
 			var/list/attach_list_of_type = attachments_text[i]
-			if(attach_list_of_type.len == 0)
+			if(length(attach_list_of_type) <= 0)
 				continue
 
 			traits += attachments_header_text[i]

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -27,15 +27,15 @@
 
 	var/list/loading_ways = list()
 	if(load_method & SINGLE_CASING)
-		loading_ways += "loose [caliber] rounds."
+		loading_ways += "loose [caliber] rounds"
 	if(load_method & SPEEDLOADER)
-		loading_ways += "speedloaders."
+		loading_ways += "speedloaders"
 	if(load_method & MAGAZINE)
-		loading_ways += "magazines."
+		loading_ways += "magazines"
 	if(load_method & CELL)
-		loading_ways += "cells."
+		loading_ways += "cells"
 	if(load_method & POWERPACK)
-		loading_ways += "it's powerpack."
+		loading_ways += "it's powerpack"
 	traits += "Can be loaded using [english_list(loading_ways)]:"
 
 	if(allowed_ammo_types)
@@ -54,7 +54,28 @@
 			var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
 			var/falloff_text = "FF:-[def_ammo.damage_falloff]/tile"
 			var/size_text = "AMMO: [mag.max_rounds]"
-			traits += "[mag.name] ([damage_text], [ap_text], [falloff_text], [size_text])"
+			traits += mag.name
+			traits += "-> [damage_text], [ap_text], [falloff_text], [size_text]"
+
+	if(load_method & SINGLE_CASING)
+		//check is done based on caliber only
+		for (var/i in typesof(/obj/item/ammo_magazine/handful))
+			var/obj/item/ammo_magazine/handful/mag = i
+			if(mag.caliber == caliber)
+				if(!mag.default_ammo)	//no ammo in mag - just print the name, otherwise add stats
+					traits += mag.name
+					continue
+
+				var/datum/ammo/bullet/def_ammo = mag.default_ammo
+				if(!mag.default_ammo.damage)
+					continue
+				var/damage_text = "DMG:[def_ammo.damage]"
+				if(def_ammo.bonus_projectiles_amount > 0)
+					damage_text += "x[def_ammo.bonus_projectiles_amount]"
+				var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
+				var/falloff_text = "FF:-[def_ammo.damage_falloff]/tile"
+				traits += def_ammo.name
+				traits += "-> [damage_text], [ap_text], [falloff_text]"
 
 	traits += "Examine the ammo holders or ammunition for more info."
 
@@ -65,7 +86,7 @@
 		traits += "Time between single-fire: [fire_delay * 0.1] seconds"
 	if(burst_amount > 1)
 		traits += "Shots fired on burst mode: [burst_amount]"
-		traits += "Time between bursts: [(burst_amount*(burst_delay-1) + fire_delay + extra_delay) * 0.1] seconds"
+		traits += "Time between bursts: [((burst_amount-1)*burst_delay + fire_delay + extra_delay) * 0.1] seconds"
 	if(/datum/action/item_action/aim_mode in actions_types)
 		traits += "Can be aimed with to shoot past allies."
 		traits += "Time between aimed shots: [(fire_delay + aim_fire_delay) * 0.1] seconds"
@@ -101,19 +122,24 @@
 			ATTACHMENT_SLOT_UNDER = "<U>Handguard attachments:</U>",
 			ATTACHMENT_SLOT_MUZZLE = "<U>Muzzle attachments:</U>",
 			ATTACHMENT_SLOT_STOCK = "<U>Stock attachments:</U>",
-			ATTACHMENT_BARREL_MOD = "<U>Barrel attachments:</U>"
+			ATTACHMENT_BARREL_MOD = "<U>Barrel attachments:</U>",
+			"other" = "<U>Other attachments:</U>"
 		)
 		var/list/attachments_text = list(
 			ATTACHMENT_SLOT_RAIL = list(),
 			ATTACHMENT_SLOT_UNDER = list(),
 			ATTACHMENT_SLOT_MUZZLE = list(),
 			ATTACHMENT_SLOT_STOCK = list(),
-			ATTACHMENT_BARREL_MOD = list()
+			ATTACHMENT_BARREL_MOD = list(),
+			"other" = list()
 		)
 
 		for(var/att in attachable_allowed)
 			var/obj/item/attachable/A = att
-			attachments_text[A.slot] += A.name
+			if(A.slot in attachments_text)
+				attachments_text[A.slot] += A.name
+			else
+				attachments_text["other"] += A.name
 		for(var/i in attachments_text)
 			var/list/attach_list_of_type = attachments_text[i]
 			if(attach_list_of_type.len > 0)

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -13,28 +13,15 @@
 /obj/item/weapon/gun/get_mechanics_info()
 	. = ..()
 	var/list/traits = list()
+	traits += "----------------------------------------------------------"
 
+	traits += "Caliber: [caliber]"
 	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY)
-		traits += "This can only be fired with a two-handed grip."
-	else
-		traits += "It's best fired with a two-handed grip."
-
-
-	if(HAS_TRAIT(src, TRAIT_GUN_SAFETY))
-		traits += "It has a safety switch. Alt-Click it to toggle safety."
-
-	if(scope_zoom) //flawed, unless you check the codex for the first time when the scope is attached, this won't show. works for sniper rifles though.
-		traits += "It has a magnifying optical scope. It can be toggled with Use Scope verb."
-
-	if(burst_amount > 2)
-		traits += "It has multiple firemodes. Click the Toggle Burst Fire button to change it."
-
-
-	traits += "<br>Caliber: [caliber]"
-
+		traits += "Can only be fired with a two-handed grip."
+	if(burst_amount > 1)
+		traits += "Can fire in short bursts. Click the Toggle Burst Fire button to change it."
 	if(max_shells)
-		traits += "It can normally hold [max_shells] rounds."
-
+		traits += "Normally holds [max_shells] rounds."
 	if(max_shots)
 		traits += "Its maximum capacity is normally [max_shots] shots worth of power."
 
@@ -51,49 +38,77 @@
 		loading_ways += "it's powerpack."
 	traits += "Can be loaded using [english_list(loading_ways)]"
 
-	if(attachable_allowed)
-		traits += "<br><U>You can attach</U>:"
-		for(var/X in attachable_allowed)
-			var/obj/item/attachable/A = X
-			traits += "[initial(A.name)]"
-
-	traits += "<br><U>Basic Statistics for this weapon are as follows</U>:"
+	traits += "----------------------------------------------------------"
 	if(w_class)
 		traits += "Size: [w_class]"
-	if(force)
-		traits += "Base melee damage: [force]"
-	if(accuracy_mult)
-		traits += "Accuracy: [((accuracy_mult - 1) * 100) > 0 ? "+[(accuracy_mult - 1) * 100]" : "[(accuracy_mult - 1) * 100]"]%"
-	if(damage_mult)
-		traits += "Damage modifier: [((damage_mult - 1) * 100) > 0 ? "+[(damage_mult - 1) * 100]" : "[(damage_mult - 1) * 100]"]%"
-	if(damage_falloff_mult)
-		traits += "Damage falloff: -[damage_falloff_mult] per tile travelled."
-	if(recoil)
-		traits += "Recoil: [recoil]"
-	if(scatter)
-		traits += "Scatter angle: [scatter]"
-	if(burst_scatter_mult)
-		traits += "Burst scatter angle multiplier: x[burst_scatter_mult]"
-	if(accuracy_mult_unwielded)
-		traits += "Accuracy unwielded modifier: [((accuracy_mult_unwielded - 1) * 100) > 0 ? "+[(accuracy_mult_unwielded - 1) * 100]" : "[(accuracy_mult_unwielded - 1) * 100]"]%"
-	if(recoil_unwielded)
-		traits += "Recoil Unwielded: [recoil_unwielded]"
-	if(scatter_unwielded)
-		traits += "Unwielded Scatter angle: [scatter_unwielded > 0 ? "+[scatter_unwielded]" : "[scatter_unwielded]"]"
-	if(movement_acc_penalty_mult)
-		traits += "Movement unwielded penalty modifier: -[(movement_acc_penalty_mult * 0.15) * 100]%"
 	if(fire_delay)
 		traits += "Time between single-fire: [fire_delay * 0.1] seconds"
-	if(wield_delay)
-		traits += "Wield delay: [wield_delay * 0.1] seconds"
 	if(burst_amount > 1)
 		traits += "Shots fired on burst mode: [burst_amount]"
-		traits += "Time between burst-fire: [(min((burst_delay * 2), (fire_delay * 3))) * 0.1] seconds"
+		traits += "Time between bursts: [(burst_amount*(burst_delay-1) + fire_delay + extra_delay) * 0.1] seconds"
 	if(/datum/action/item_action/aim_mode in actions_types)
 		traits += "Can be aimed with to shoot past allies."
 		traits += "Time between aimed shots: [(fire_delay + aim_fire_delay) * 0.1] seconds"
+	if(wield_delay)
+		traits += "Wield delay: [wield_delay * 0.1] seconds"
+	if(force)
+		traits += "Melee damage: [force]"
+	if(damage_mult <> 1)
+		traits += "Damage multiplier: x[damage_mult]"
+	if(damage_falloff_mult <> 1)
+		traits += "Damage falloff multiplier: x[damage_falloff_mult]"
+	if(accuracy_mult <> 1)
+		traits += "Accuracy multiplier: x[accuracy_mult]"
+	if(accuracy_mult_unwielded)
+		traits += "Accuracy unwielded multiplier: x[accuracy_mult_unwielded]"
+	if(movement_acc_penalty_mult)
+		traits += "Moving accuracy (flat malus): -[(movement_acc_penalty_mult * 3)]%"
+	if(recoil)
+		traits += "Recoil: [recoil]"
+	if(recoil_unwielded)
+		traits += "Recoil unwielded: [recoil_unwielded]"
+	if(scatter)
+		traits += "Scatter angle: [scatter]"
+	if(scatter_unwielded)
+		traits += "Unwielded scatter angle: [scatter_unwielded]"
+	if(burst_scatter_mult <> 1)
+		traits += "Burst scatter angle multiplier: x[burst_scatter_mult]"
 
-	traits += "<br>"
+	traits += "----------------------------------------------------------"
+	if(attachable_allowed)
+		var/list/attachments_header_text = list(
+			"<U>Rail attachments:</U>",
+			"<U>Handguard attachments:</U>",
+			"<U>Muzzle attachments:</U>",
+			"<U>Stock attachments:</U>",
+			"<U>Barrel attachments:</U>",
+			"<U>Other attachments:</U>"
+		)
+		var/list/attachments_text = list(
+			ATTACHMENT_SLOT_RAIL = list(),
+			ATTACHMENT_SLOT_UNDER = list(),
+			ATTACHMENT_SLOT_MUZZLE = list(),
+			ATTACHMENT_SLOT_STOCK = list(),
+			ATTACHMENT_BARREL_MOD = list(),
+			"other" = list()
+		)
+
+		for(var/att in attachable_allowed)
+			var/obj/item/attachable/A = att
+			if (A.slot in attachments_text)
+				attachments_text[A.slot] += A.name
+			else
+				attachments_text["other"] += A.name
+		for(var/i in 1 to attachments_text.len)
+			traits += "[i]"
+			if(attachments_text[i])
+				traits += attachments_header_text[i]
+				for(var/X in attachments_text[i])
+					traits += X
+				//attachments_text[i] = sortList(attachments_text[i])
+
+	traits += "----------------------------------------------------------"
+	traits += "How to use:<br>"
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
 	if(general_entry?.mechanics_text)

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -76,36 +76,37 @@
 
 	traits += "----------------------------------------------------------"
 	if(attachable_allowed)
+		var/list/attach_types = list(
+			ATTACHMENT_SLOT_RAIL,
+			ATTACHMENT_SLOT_UNDER,
+			ATTACHMENT_SLOT_MUZZLE,
+			ATTACHMENT_SLOT_STOCK,
+			ATTACHMENT_BARREL_MOD
+		)
 		var/list/attachments_header_text = list(
-			"<U>Rail attachments:</U>",
-			"<U>Handguard attachments:</U>",
-			"<U>Muzzle attachments:</U>",
-			"<U>Stock attachments:</U>",
-			"<U>Barrel attachments:</U>",
-			"<U>Other attachments:</U>"
+			ATTACHMENT_SLOT_RAIL = "<U>Rail attachments:</U>",
+			ATTACHMENT_SLOT_UNDER = "<U>Handguard attachments:</U>",
+			ATTACHMENT_SLOT_MUZZLE = "<U>Muzzle attachments:</U>",
+			ATTACHMENT_SLOT_STOCK = "<U>Stock attachments:</U>",
+			ATTACHMENT_BARREL_MOD = "<U>Barrel attachments:</U>"
 		)
 		var/list/attachments_text = list(
 			ATTACHMENT_SLOT_RAIL = list(),
 			ATTACHMENT_SLOT_UNDER = list(),
 			ATTACHMENT_SLOT_MUZZLE = list(),
 			ATTACHMENT_SLOT_STOCK = list(),
-			ATTACHMENT_BARREL_MOD = list(),
-			"other" = list()
+			ATTACHMENT_BARREL_MOD = list()
 		)
 
 		for(var/att in attachable_allowed)
 			var/obj/item/attachable/A = att
-			if (A.slot in attachments_text)
-				attachments_text[A.slot] += A.name
-			else
-				attachments_text["other"] += A.name
-		for(var/i in 1 to attachments_text.len)
-			traits += "[i]"
-			if(attachments_text[i])
+			attachments_text[A.slot] += A.name
+		for(var/i in attachments_text)
+			var/list/attach_list_of_type = attachments_text[i]
+			if(attach_list_of_type.len > 0)
 				traits += attachments_header_text[i]
-				for(var/X in attachments_text[i])
-					traits += X
-				//attachments_text[i] = sortList(attachments_text[i])
+				attachments_text[i] = sortList(attachments_text[i])
+				traits += attachments_text[i]
 
 	traits += "----------------------------------------------------------"
 	traits += "How to use:<br>"

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -36,7 +36,27 @@
 		loading_ways += "cells."
 	if(load_method & POWERPACK)
 		loading_ways += "it's powerpack."
-	traits += "Can be loaded using [english_list(loading_ways)]"
+	traits += "Can be loaded using [english_list(loading_ways)]:"
+
+	if(allowed_ammo_types)
+		for(var/i in allowed_ammo_types)
+			var/obj/item/ammo_magazine/mag = i
+			if(!mag.default_ammo)	//no ammo in mag - just print the name, otherwise add stats
+				traits += mag.name
+				continue
+
+			var/datum/ammo/bullet/def_ammo = mag.default_ammo
+			if(!mag.default_ammo.damage)
+				continue
+			var/damage_text = "DMG:[def_ammo.damage]"
+			if(def_ammo.bonus_projectiles_amount > 0)
+				damage_text += "x[def_ammo.bonus_projectiles_amount]"
+			var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
+			var/falloff_text = "FF:-[def_ammo.damage_falloff]/tile"
+			var/size_text = "AMMO: [mag.max_rounds]"
+			traits += "[mag.name] ([damage_text], [ap_text], [falloff_text], [size_text])"
+
+	traits += "Examine the ammo holders or ammunition for more info."
 
 	traits += "----------------------------------------------------------"
 	if(w_class)
@@ -76,13 +96,6 @@
 
 	traits += "----------------------------------------------------------"
 	if(attachable_allowed)
-		var/list/attach_types = list(
-			ATTACHMENT_SLOT_RAIL,
-			ATTACHMENT_SLOT_UNDER,
-			ATTACHMENT_SLOT_MUZZLE,
-			ATTACHMENT_SLOT_STOCK,
-			ATTACHMENT_BARREL_MOD
-		)
 		var/list/attachments_header_text = list(
 			ATTACHMENT_SLOT_RAIL = "<U>Rail attachments:</U>",
 			ATTACHMENT_SLOT_UNDER = "<U>Handguard attachments:</U>",

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -19,7 +19,7 @@
 	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY)
 		traits += "Can only be fired with a two-handed grip."
 	if(burst_amount > 1)
-		traits += "Can fire in short bursts. Click the Toggle Burst Fire button to change it."
+		traits += "Can fire in short bursts."
 	if(max_shells)
 		traits += "Normally holds [max_shells] rounds."
 	if(max_shots)
@@ -36,7 +36,7 @@
 		loading_ways += "cells"
 	if(load_method & POWERPACK)
 		loading_ways += "it's powerpack"
-	traits += "Can be loaded using [english_list(loading_ways)]:"
+	traits += "Can be loaded using: [english_list(loading_ways)]:"
 
 	if(allowed_ammo_types)
 		for(var/i in allowed_ammo_types)
@@ -52,7 +52,7 @@
 			if(def_ammo.bonus_projectiles_amount > 0)
 				damage_text += "x[def_ammo.bonus_projectiles_amount]"
 			var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
-			var/falloff_text = "FF:-[def_ammo.damage_falloff]/tile"
+			var/falloff_text = "FLF:-[def_ammo.damage_falloff]/tile"
 			var/size_text = "AMMO: [mag.max_rounds]"
 			traits += mag.name
 			traits += "-> [damage_text], [ap_text], [falloff_text], [size_text]"
@@ -61,21 +61,22 @@
 		//check is done based on caliber only
 		for (var/i in typesof(/obj/item/ammo_magazine/handful))
 			var/obj/item/ammo_magazine/handful/mag = i
-			if(mag.caliber == caliber)
-				if(!mag.default_ammo)	//no ammo in mag - just print the name, otherwise add stats
-					traits += mag.name
-					continue
+			if(mag.caliber != caliber)
+				continue
+			if(!mag.default_ammo)	//no ammo in mag - just print the name, otherwise add stats
+				traits += mag.name
+				continue
 
-				var/datum/ammo/bullet/def_ammo = mag.default_ammo
-				if(!mag.default_ammo.damage)
-					continue
-				var/damage_text = "DMG:[def_ammo.damage]"
-				if(def_ammo.bonus_projectiles_amount > 0)
-					damage_text += "x[def_ammo.bonus_projectiles_amount]"
-				var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
-				var/falloff_text = "FF:-[def_ammo.damage_falloff]/tile"
-				traits += def_ammo.name
-				traits += "-> [damage_text], [ap_text], [falloff_text]"
+			var/datum/ammo/bullet/def_ammo = mag.default_ammo
+			if(!mag.default_ammo.damage)
+				continue
+			var/damage_text = "DMG:[def_ammo.damage]"
+			if(def_ammo.bonus_projectiles_amount > 0)
+				damage_text += "x[def_ammo.bonus_projectiles_amount]"
+			var/ap_text = "AP:[def_ammo.penetration+def_ammo.additional_xeno_penetration]"
+			var/falloff_text = "FLF:-[def_ammo.damage_falloff]/tile"
+			traits += def_ammo.name
+			traits += "-> [damage_text], [ap_text], [falloff_text]"
 
 	traits += "Examine the ammo holders or ammunition for more info."
 
@@ -142,10 +143,12 @@
 				attachments_text["other"] += A.name
 		for(var/i in attachments_text)
 			var/list/attach_list_of_type = attachments_text[i]
-			if(attach_list_of_type.len > 0)
-				traits += attachments_header_text[i]
-				attachments_text[i] = sortList(attachments_text[i])
-				traits += attachments_text[i]
+			if(attach_list_of_type.len == 0)
+				continue
+
+			traits += attachments_header_text[i]
+			attachments_text[i] = sortList(attachments_text[i])
+			traits += attachments_text[i]
 
 	traits += "----------------------------------------------------------"
 	traits += "How to use:<br>"


### PR DESCRIPTION
## `Основные изменения`

При осмотре в кодексе больше информации, в более понятном формате.

![image](https://github.com/user-attachments/assets/e062400f-36d5-42c1-956a-8e4c70ba8108)
![image](https://github.com/user-attachments/assets/cc12f56f-e402-461a-ba6e-a1944dabaaf2)
![image](https://github.com/user-attachments/assets/233608b3-0eb6-4847-806a-cc37d01b49a4)
![image](https://github.com/user-attachments/assets/b1fd2cb7-c829-4a53-9f66-db61decd342f)

Инфа про урон не работает на лаз оружие (это не огнестрел лол).


## `Как это улучшит игру`

Астрологи объявили неделю QoL. Количество необходимых вики-страниц сократилось вдвое.

## `Ченджлог`

```
:cl:
qol: Кодекс (осмотр) оружия показывает больше информации
/:cl:
```
