### PR TITLE
Чуть больше удобства с имиалки 

### DIFF
--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -161,6 +161,7 @@
 			/obj/item/storage/pill_bottle/spaceacillin = 6,
 			/obj/item/storage/pill_bottle/alkysine = 6,
 			/obj/item/storage/pill_bottle/imidazoline = 6,
+			/obj/item/storage/pill_bottle/imialky = 6,
 			/obj/item/storage/pill_bottle/hypervene = 6,
 		),
 		"Hypospray" = list (
@@ -264,6 +265,7 @@
 			/obj/item/storage/pill_bottle/spaceacillin = -1,
 			/obj/item/storage/pill_bottle/alkysine = -1,
 			/obj/item/storage/pill_bottle/imidazoline = -1,
+			/obj/item/storage/pill_bottle/imialky = -1,
 			/obj/item/storage/pill_bottle/quickclot = -1,
 			/obj/item/storage/pill_bottle/hypervene = -1,
 			/obj/item/storage/pill_bottle/russian_red = -1,


### PR DESCRIPTION
## `Основные изменения`

Имиалки теперь не только спаунится в медпоясах, но и в наномед плюсе в количестве шести банок
## `Как это улучшит игру`

Не нужно брать пояса со склада или сливать инъекторы в бикер, банку со смесью можно взять в вендоре. Продолжение логики с сахаром и комбатмиксом, отчасти с сино и прочим, когда морпехам нет необходимости ничего делать в химии, всё необходимое сварено/намешено за них и так, что в общем-то удобно и экономит время, убирая рутинну.

## `Ченджлог`
```
:cl:
qol: Имиалки теперь есть в ограниченном количестве в Наномед Плюс.
/:cl:
```
