### PR TITLE
Storage can be open on click with too big item

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -557,7 +557,7 @@
 				return do_refill(I, user)
 
 	if(!can_be_inserted(I))
-		if(!user.s_active) // Don't close open storage menu if can't insert something, if storage dosen't open it will be open
+		if(user.s_active != src) // Don't close open storage menu if can't insert something, if storage dosen't open it will be open
 			open(user)
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)


### PR DESCRIPTION
## `Основные изменения`
Насрал, исправил, теперь это работает на 1 iq лучше, вроде теперь все должны быть довольны...
## `Как это улучшит игру`
## `Ченджлог`
```
:cl:
fix: При клике не вмещаемым предметом, если этот контейнер не был открыт, он откроется.
/:cl:
```
