### PR TITLE
Hunter blink change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -245,7 +245,7 @@
 	new /obj/effect/particle_effect/sparks(target_turf)
 	playsound(target_turf, 'sound/effects/EMPulse.ogg', 25, TRUE)
 
-	X.forceMove(A.loc)
+	X.forceMove(target_turf)
 	X.apply_status_effect(/datum/status_effect/hunt)
 
 	succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -239,19 +239,13 @@
 	var/turf/target_turf = get_turf(A)
 	var/turf/origin_turf = get_turf(X)
 
-	target_turf = get_step_rand(target_turf)
-
 	new /obj/effect/temp_visual/blink_portal(origin_turf)
 	new /obj/effect/temp_visual/blink_portal(target_turf)
 	new /obj/effect/particle_effect/sparks(origin_turf)
 	new /obj/effect/particle_effect/sparks(target_turf)
 	playsound(target_turf, 'sound/effects/EMPulse.ogg', 25, TRUE)
 
-	if(target_turf)
-		X.forceMove(target_turf)
-	else
-		X.forceMove(A.loc)
-
+	X.forceMove(A.loc)
 	X.apply_status_effect(/datum/status_effect/hunt)
 
 	succeed_activate()


### PR DESCRIPTION
## `Основные изменения`

Блинк хантера теперь телепортирует на тайл цели, а не на случайный соседний.

## `Как это улучшит игру`

На каждый новый абуз придется кучу говнокода писать. В измененном виде абилка уже проблем доставлять не будет.

## `Ченджлог`
```
:cl:
add: Блинк хантера теперь телепортирует на тайл цели, а не на случайный соседний.
/:cl:
```
