### PR TITLE
Замена префикса для ксено языка

### DIFF
--- a/code/modules/language/xenocommon.dm
+++ b/code/modules/language/xenocommon.dm
@@ -5,7 +5,7 @@
 	ask_verb = "hisses"
 	exclaim_verb = "hisses"
 	sing_verb = "hisses melodically"
-	key = "x"
+	key = "4"
 	syllables = list("sss", "sSs", "SSS")
 	default_priority = 50
 


### PR DESCRIPTION
## `Основные изменения`

Заменил префикс `,x` на `,4`, дабы было чуть удобней общаться с ксеносами, ибо если вписать `,ч`, то ничего не произойдёт.
Почему не добавил `list("ч", "x")`? Да потому что оно почему-то отказывается нормально работать, а переделывать целую систему ради одного ксеноязыка как-то не особо хочется.

## `Как это улучшит игру`

Упростит синтам ксеноагентство.

## `Ченджлог`

```
:cl:Basia
fix: Заменил ",x" на ",4" для общения с ксеносами на их языке.
/:cl:
```