### PR TITLE
Tweak/nerf Alkyzine

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -622,8 +622,8 @@
 	desc = "A hypospray loaded with a mixture of imidazoline and alkysine. Chemicals that will heal brain, eyes, and ears."
 	amount_per_transfer_from_this = 5
 	list_reagents = list(
-		/datum/reagent/medicine/imidazoline = 96,
-		/datum/reagent/medicine/alkysine = 24,
+		/datum/reagent/medicine/imidazoline = 60,
+		/datum/reagent/medicine/alkysine = 60,
 	)
 	description_overlay = "Im"
 

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -250,7 +250,7 @@
 
 /obj/item/reagent_containers/pill/imialky
 	pill_desc = "An imialky pill. Used to fix brain, ear and eye damage."
-	list_reagents = list(/datum/reagent/medicine/alkysine = 3.5, /datum/reagent/medicine/imidazoline = 11.5)
+	list_reagents = list(/datum/reagent/medicine/alkysine = 7.5, /datum/reagent/medicine/imidazoline = 7.5)
 	pill_id = 18
 
 /obj/item/reagent_containers/pill/combatmix

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -691,7 +691,6 @@
 	name = "Alkysine"
 	description = "Alkysine is a drug used to lessen the damage to neurological and auditory tissue after a catastrophic injury. Can heal brain and ear tissue."
 	color = COLOR_REAGENT_ALKYSINE
-	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE

--- a/code/modules/reqs/supplypacks/medical.dm
+++ b/code/modules/reqs/supplypacks/medical.dm
@@ -284,10 +284,10 @@
 
 /datum/supply_packs/medical/imialky_kit
 	name = "ImiAlky kit"
-	notes = "contains pill bottles imidazoline and alkysine."
+	notes = "contains pill bottles imialky."
 	contains = list(
-		/obj/item/storage/pill_bottle/imidazoline,
-		/obj/item/storage/pill_bottle/alkysine,
+		/obj/item/storage/pill_bottle/imialky,
+		/obj/item/storage/pill_bottle/imialky,
 	)
 	cost = 30
 


### PR DESCRIPTION
## `Основные изменения`
1) Метаболизация Алкизина равна метаболизации Имидазолина.
2) Заменил в карго крейте таблетки на ИмиАлки, вместо своих полновесных аналогов.

## `Как это улучшит игру`
Непонятно, кто вообще кодил Алкизин и Имидазолин.
Они имеют фактически одинаковый эффект, только для разных двух зон головы.
При этом имеют различный метаболизм.
Для излечения стандартного урона по мозгу требуется 20 тиков лечения Алкизину. Это эквивалентно 1u реагента(как мы помним, в таблетке аж 3,5u).
Для излечения стандартного максимального урона по глазам требуется 30 тиков Имидазолина. Это эквивалентно 6u реагента(Как мы помним, в таблетке аж 11,5u).
Какого блин, хуя?
Если сделать их метаболизм равным и сделать равным соотношение 1:1, то в итоге у нас получится 7,5 : 7,5 u реагентов.
При равном метаболизме Алкизину потребуется 4u для лечения максимального количества урона мозга и ушей.
При равном метаболизме Имидазолину потребуется 6u для лечения максимального количества урона глазам.

Да, возможно это понерфит Алкизин как чертов препарат против токсинов(Хотя они вообще не заявлены как таковые нигде в коде). Однако это полностью приведет данные препараты к единообразному виду.
Количества препаратов всё еще будет хватать для фулл выхила с одной таблетки, всё еще будут хилить токсины.
Однако количества ебли с рецептурой снизится категорически.

pr: Единственное, что можно было бы изменить в этом ПРе, это сделать обоим реагентам метаболизацию от стандартной 0,25 или 0,15 к примеру. Чтобы это создавало неудобства при ебле с таблетками уровня метаболизации БККТ, ибо ИмиАлки всё же не должен жраться на уровне с обычной химозой в качестве защиты от токсинов.

## `Ченджлог`

```
:cl:
balance: Метаболизация Алкизина отныне равна Имидазолину. Количество реагентов в контейнерах 1:1 
/:cl:
```

