### PR TITLE
Больше модулей на Нигредо

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/revolver.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/revolver.dm
@@ -27,6 +27,7 @@
 	handful_amount = 5
 	damage = 100
 	penetration = 40
+	max_range = 25
 	additional_xeno_penetration = 0
 
 /datum/ammo/bullet/revolver/t500/on_hit_mob(mob/M,obj/projectile/P)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -532,9 +532,20 @@
 		/obj/item/attachable/stock/t500stock,
 		/obj/item/attachable/t500barrelshort,
 		/obj/item/attachable/t500barrel,
-		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/lace/t500,
+		/obj/item/attachable/reddot,
+		/obj/item/attachable/verticalgrip,
+		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/flashlight/under,
+		/obj/item/attachable/lasersight,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/marine,
+		/obj/item/attachable/scope/mini,
+		/obj/item/attachable/motiondetector,
+		/obj/item/attachable/buildasentry,
+		/obj/item/attachable/shoulder_mount,
 	)
 	attachable_offset = list("muzzle_x" = 0, "muzzle_y" = 0,"rail_x" = 10, "rail_y" = 20, "under_x" = 19, "under_y" = 13, "stock_x" = -19, "stock_y" = 0)
 	windup_delay = 0.8 SECONDS


### PR DESCRIPTION
## `Основные изменения`

Больше модулей на Нигредо, добавил более далёкий полёт пули по сравнению с обычным револьвером, но меньше, чем у снайперок (у них по 40), чтобы можно было использовать его как снайперское оружие, но без ифф и аима. Пуля летит как раз до границы снайперского прицела.

## `Как это улучшит игру`

Рофлоган получит больше применений, возможно станет немного более играбельным или хотя бы интересным. Снайперский револьвер с вертикальной рукояткой звучит круто!
![image](https://github.com/user-attachments/assets/861c4316-7ab9-4378-ad82-449017cc4950)

## `Ченджлог`
```
:cl:
balance: Больше модулей на R-500, в том числе прицелы и рукояти
balance: Пули R-500 летят дальше обычных на 5 тайлов.
/:cl:
```
