### PR TITLE
Roadmap - Vali rapir delete skill lock

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -106,7 +106,6 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjector", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
-	/obj/item/storage/holster/blade/officer/valirapier/full = list(CAT_MARINE, "Vali Harvester rapier", 45, "blue"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 8, "blue"),
 	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "blue"),

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjector", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
+	/obj/item/storage/holster/blade/officer/valirapier/full = list(CAT_MARINE, "Vali Harvester rapier", 25, "blue"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 8, "blue"),
 	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "blue"),

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjector", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
-	/obj/item/storage/holster/blade/officer/valirapier/full = list(CAT_MARINE, "Vali Harvester rapier", 25, "blue"),
+	/obj/item/storage/holster/blade/officer/valirapier/full = list(CAT_MARINE, "Vali Harvester rapier", 45, "blue"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 8, "blue"),
 	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "blue"),

--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -23,12 +23,7 @@
 #define SKILL_LARGE_VEHICLE "large_vehicle"
 #define SKILL_MECH_PILOT "mech_pilot"
 #define SKILL_STAMINA "stamina"
-#define SKILL_SWORDPLAY "swordplay"
 ////////////////////////////////////////////////
-
-//ability to use elegant melee weapons (i.e. rapiers)
-#define SKILL_SWORDPLAY_DEFAULT 0
-#define SKILL_SWORDPLAY_TRAINED 1
 
 //firearms skill (general knowledge of guns) (hidden skill)
 //increase or decrase accuracy, recoil, and firing delay of rifles and smgs.
@@ -146,6 +141,7 @@
 #define SKILL_MELEE_DEFAULT 0
 #define SKILL_MELEE_TRAINED 1
 #define SKILL_MELEE_SUPER 2
+#define SKILL_MELEE_MASTER 3
 
 ///The amount of extra damage per melee skill level
 #define MELEE_SKILL_DAM_BUFF 0.15

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -1,22 +1,18 @@
 #define SKILLSID "skills-[cqc]-[melee_weapons]\
 -[firearms]-[pistols]-[shotguns]-[rifles]-[smgs]-[heavy_weapons]-[smartgun]\
--[swordplay]\
 -[engineer]-[construction]-[leadership]-[medical]-[surgery]-[pilot]-[police]-[powerloader]-[large_vehicle]-[mech_pilot]-[stamina]"
 
 #define SKILLSIDSRC(S) "skills-[S.cqc]-[S.melee_weapons]\
 -[S.firearms]-[S.pistols]-[S.shotguns]-[S.rifles]-[S.smgs]-[S.heavy_weapons]-[S.smartgun]\
--[S.swordplay]\
 -[S.engineer]-[S.construction]-[S.leadership]-[S.medical]-[S.surgery]-[S.pilot]-[S.police]-[S.powerloader]-[S.large_vehicle]-[mech_pilot]-[S.stamina]"
 
 /proc/getSkills(cqc = 0, melee_weapons = 0,\
 firearms = 0, pistols = 0, shotguns = 0, rifles = 0, smgs = 0, heavy_weapons = 0, smartgun = 0,\
-swordplay = 0,\
 engineer = 0, construction = 0, leadership = 0, medical = 0, surgery = 0, pilot = 0, police = 0, powerloader = 0, large_vehicle = 0, mech_pilot = 0, stamina = 0)
 	. = locate(SKILLSID)
 	if(!.)
 		. = new /datum/skills(cqc, melee_weapons,\
 			firearms, pistols, shotguns, rifles, smgs, heavy_weapons, smartgun,\
-			swordplay,\
 			engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle, mech_pilot, stamina)
 
 /proc/getSkillsType(skills_type = /datum/skills)
@@ -41,9 +37,6 @@ engineer = 0, construction = 0, leadership = 0, medical = 0, surgery = 0, pilot 
 	var/large_vehicle = initial(new_skill.large_vehicle)
 	var/mech_pilot = initial(new_skill.mech_pilot)
 	var/stamina = initial(new_skill.stamina)
-	//RUTGMC EDIT ADDITION BEGIN - SWORDS
-	var/swordplay = initial(new_skill.swordplay)
-	//RUTGMC EDIT ADDITION END
 	. = locate(SKILLSID)
 	if(!.)
 		. = new skills_type
@@ -74,13 +67,10 @@ engineer = 0, construction = 0, leadership = 0, medical = 0, surgery = 0, pilot 
 	var/mech_pilot = SKILL_MECH_PILOT_DEFAULT
 	///Effects stamina regen rate and regen delay
 	var/stamina = SKILL_STAMINA_DEFAULT
-	//RUTGMC EDIT ADDITION BEGIN - SWORDS
-	var/swordplay = SKILL_SWORDPLAY_DEFAULT
-	//RUTGMC EDIT ADDITION END
 
 
 /datum/skills/New(cqc, melee_weapons,\
-firearms, pistols, shotguns, rifles, smgs, heavy_weapons, swordplay, smartgun,\
+firearms, pistols, shotguns, rifles, smgs, heavy_weapons, smartgun,\
 engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle, mech_pilot, stamina)
 	if(!isnull(cqc))
 		src.cqc = cqc
@@ -122,15 +112,11 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		src.mech_pilot = mech_pilot
 	if(!isnull(stamina))
 		src.stamina = stamina
-	//RUTGMC EDIT ADDITION BEGIN - SWORDS
-	if(!isnull(swordplay))
-		src.swordplay = swordplay
-	//RUTGMC EDIT ADDITION END
 	tag = SKILLSIDSRC(src)
 
 /// returns/gets a new skills datum with values changed according to the args passed
 /datum/skills/proc/modifyRating(cqc, melee_weapons,\
-firearms, pistols, shotguns, rifles, smgs, heavy_weapons, swordplay, smartgun,\
+firearms, pistols, shotguns, rifles, smgs, heavy_weapons, smartgun,\
 engineer, construction, leadership, medical, surgery, pilot, police, powerloader, large_vehicle, mech_pilot, stamina)
 	return getSkills(src.cqc+cqc,\
 	src.melee_weapons+melee_weapons,\
@@ -140,7 +126,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	src.rifles+rifles,\
 	src.smgs+smgs,\
 	src.heavy_weapons+heavy_weapons,\
-	src.swordplay+swordplay,\
 	src.smartgun+smartgun,\
 	src.engineer+engineer,\
 	src.construction+construction,\
@@ -164,7 +149,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	src.rifles+difference,\
 	src.smgs+difference,\
 	src.heavy_weapons+difference,\
-	src.swordplay+difference,\
 	src.smartgun+difference,\
 	src.engineer+difference,\
 	src.construction+difference,\
@@ -191,7 +175,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		(isnull(smgs) ? src.smgs : smgs),\
 		(isnull(heavy_weapons) ? src.heavy_weapons : heavy_weapons),\
 		(isnull(smartgun) ? src.smartgun : smartgun),\
-		(isnull(swordplay) ? src.swordplay : swordplay),\
 		(isnull(engineer) ? src.engineer : engineer),\
 		(isnull(construction) ? src.construction : construction),\
 		(isnull(leadership) ? src.leadership : leadership),\
@@ -232,7 +215,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 		SKILL_SMGS = smgs,
 		SKILL_HEAVY_WEAPONS = heavy_weapons,
 		SKILL_SMARTGUN = smartgun,
-		SKILL_SWORDPLAY = swordplay,
 		SKILL_ENGINEER = engineer,
 		SKILL_CONSTRUCTION = construction,
 		SKILL_LEADERSHIP = leadership,
@@ -398,7 +380,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	powerloader = SKILL_POWERLOADER_MASTER
 	firearms = SKILL_FIREARMS_TRAINED
 	smartgun = SKILL_SMART_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 
 /datum/skills/fo
@@ -411,7 +392,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	police = SKILL_POLICE_MP
 	powerloader = SKILL_POWERLOADER_TRAINED
 	cqc = SKILL_CQC_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 	smartgun = SKILL_SMART_TRAINED
 
 /datum/skills/so
@@ -421,7 +401,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_AMATEUR
 	police = SKILL_POLICE_MP
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/pilot
 	name = PILOT_OFFICER
@@ -491,7 +470,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
 	police = SKILL_POLICE_MP
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/sl
 	name = SQUAD_LEADER
@@ -501,7 +479,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	leadership = SKILL_LEAD_EXPERT
 	medical = SKILL_MEDICAL_NOVICE
 	surgery = SKILL_SURGERY_AMATEUR
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/sl/clf
 	name = "CLF leader"
@@ -597,7 +574,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	rifles = SKILL_RIFLES_TRAINED
 	shotguns = SKILL_SHOTGUNS_TRAINED
 	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/commando/medic
 	name = "Commando Medic"
@@ -623,7 +599,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	rifles = SKILL_RIFLES_TRAINED
 	shotguns = SKILL_SHOTGUNS_TRAINED
 	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/admiral
 	name = "Admiral"
@@ -633,7 +608,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	surgery = SKILL_SURGERY_AMATEUR
 	police = SKILL_POLICE_FLASH
 	powerloader = SKILL_POWERLOADER_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /datum/skills/spatial_agent
 	name = "Spatial Agent"
@@ -644,7 +618,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	medical = SKILL_MEDICAL_MASTER
 	cqc = SKILL_CQC_MASTER
 	surgery = SKILL_SURGERY_EXPERT
-	melee_weapons = SKILL_MELEE_SUPER
+	melee_weapons = SKILL_MELEE_MASTER
 	leadership = SKILL_LEAD_MASTER
 	pilot = SKILL_PILOT_TRAINED
 	pistols = SKILL_PISTOLS_TRAINED
@@ -656,7 +630,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	powerloader = SKILL_POWERLOADER_MASTER
 	large_vehicle = SKILL_LARGE_VEHICLE_VETERAN
 	mech_pilot = SKILL_MECH_PILOT_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 /* Deathsquad */
 /datum/skills/deathsquad
@@ -722,7 +695,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
 	smartgun = SKILL_SMART_USE // can use smartgun
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 	// higher SL skills
 	engineer = SKILL_ENGINEER_ENGI
@@ -749,7 +721,6 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	smgs = SKILL_SMGS_TRAINED
 	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED
 	smartgun = SKILL_SMART_TRAINED
-	swordplay = SKILL_SWORDPLAY_TRAINED
 
 	//endurance = 0 - does nothing
 	engineer = SKILL_ENGINEER_PLASTEEL
@@ -808,8 +779,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	medical = SKILL_MEDICAL_MASTER
 	cqc = SKILL_CQC_MASTER
 	surgery = SKILL_SURGERY_EXPERT
-	melee_weapons = SKILL_MELEE_SUPER
+	melee_weapons = SKILL_MELEE_MASTER
 	pistols = SKILL_PISTOLS_TRAINED
 	rifles = SKILL_RIFLES_TRAINED
 	police = SKILL_POLICE_MP
-	swordplay = SKILL_SWORDPLAY_TRAINED

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -131,22 +131,6 @@
 	attack_verb = list("slash", "cut")
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/weapon/claymore/mercsword/officersword/attack(mob/living/carbon/M, mob/living/user)
-	. = ..()
-	if(user.skills.getRating("swordplay") == SKILL_SWORDPLAY_DEFAULT)
-		attack_speed = 20
-		force = 35
-		to_chat(user, span_warning("You try to figure out how to wield [src]..."))
-		if(prob(40))
-			if(HAS_TRAIT_FROM(src, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT))
-				REMOVE_TRAIT(src, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
-			user.drop_held_item(src)
-			to_chat(user, span_warning("[src] slipped out of your hands!"))
-			playsound(src.loc, 'sound/misc/slip.ogg', 25, 1)
-	if(user.skills.getRating("swordplay") == SKILL_SWORDPLAY_TRAINED)
-		attack_speed = initial(attack_speed)
-		force = initial(force)
-
 /obj/item/weapon/claymore/mercsword/officersword/equipped(mob/user, slot)
 	. = ..()
 	toggle_item_bump_attack(user, TRUE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -474,7 +474,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	return TRUE
 
 /mob/living/carbon/human/proc/check_pred_shields(damage = 0, attack_text = "the attack", combistick = FALSE, backside_attack = FALSE, xenomorph = FALSE)
-	if(skills.getRating("swordplay") < SKILL_SWORDPLAY_TRAINED)
+	if(skills.getRating("melee_weapons") < SKILL_MELEE_MASTER)
 		return FALSE
 
 	var/block_effect = /obj/effect/temp_visual/block


### PR DESCRIPTION
## `Основные изменения`
Убрал лок на валирапиру, теперь скилл не требуется, по приказу генерала татарла (роад мап). Блок предаторов теперь зависит не от скилла рапиры а из-за мили скилла
## `Как это улучшит игру`
## `Ченджлог`
```
:cl:
add: Теперь для использования вали рапиры не требуется скилл
/:cl:
```
