### PR TITLE
Port strapable fixes

### DIFF
--- a/code/datums/elements/strappable.dm
+++ b/code/datums/elements/strappable.dm
@@ -7,9 +7,10 @@
 
 /datum/element/strappable/Detach(datum/source, ...)
 	. = ..()
-	UnregisterSignal(source, COMSIG_CLICK_ALT)
+	UnregisterSignal(source, list(COMSIG_CLICK_ALT, COMSIG_ITEM_UNEQUIPPED))
 	REMOVE_TRAIT(source, TRAIT_STRAPPABLE, STRAPPABLE_ITEM_TRAIT)
 
+///Toggles strap state
 /datum/element/strappable/proc/on_alt_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 	var/obj/item/item_source = source
@@ -19,8 +20,16 @@
 		return
 	var/strapped = HAS_TRAIT_FROM(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 	if(!strapped)
+		RegisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED, PROC_REF(on_unequip))
 		ADD_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 		item_source.balloon_alert(user, "Tightened strap")
 	else
+		UnregisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED)
 		REMOVE_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)
 		item_source.balloon_alert(user, "Loosened strap")
+
+///Unstraps if the target is somehow forcefully unequipped
+/datum/element/strappable/proc/on_unequip(obj/item/item_source, mob/unequipper, slot)
+	SIGNAL_HANDLER
+	UnregisterSignal(item_source, COMSIG_ITEM_UNEQUIPPED)
+	REMOVE_TRAIT(item_source, TRAIT_NODROP, STRAPPABLE_ITEM_TRAIT)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -259,19 +259,13 @@
 		if(!do_after(src, W.equip_delay_self, NONE, W, BUSY_ICON_FRIENDLY))
 			to_chat(src, "You stop putting on \the [W]")
 			return FALSE
-		if(!W.mob_can_equip(src, slot, warning, override_nodrop))
-			return FALSE
-		equip_to_slot(W, slot) //This proc should not ever fail.
-		//This will unwield items -without- triggering lights.
-		if(CHECK_BITFIELD(W.flags_item, TWOHANDED))
-			W.unwield(src)
-		return TRUE
-	else
-		equip_to_slot(W, slot) //This proc should not ever fail.
-		//This will unwield items -without- triggering lights.
-		if(CHECK_BITFIELD(W.flags_item, TWOHANDED))
-			W.unwield(src)
-		return TRUE
+		//calling the proc again with ignore_delay saves a boatload of copypaste
+		return equip_to_slot_if_possible(W, slot, TRUE, del_on_fail, warning, redraw_mob, override_nodrop)
+	equip_to_slot(W, slot) //This proc should not ever fail.
+	//This will unwield items -without- triggering lights.
+	if(CHECK_BITFIELD(W.flags_item, TWOHANDED))
+		W.unwield(src)
+	return TRUE
 
 /**
 *This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.


### PR DESCRIPTION
## `Основные изменения`
Запортил фикс некоторыз багов, теперь будет меньше фантомных предметов, и например, нельзя будет положить застрапленный предмет.
## `Как это улучшит игру`
## `Ченджлог`
```
:cl:
fix: Привязанные предметы нельзя положить на стол и фантомно размножить.
/:cl:
```
