### PR TITLE
Изменение влияния силы взрыва на слоудаун от него

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -44,8 +44,8 @@
 
 	var/powerfactor_value = round(severity * 0.05, 1)
 	powerfactor_value = min(powerfactor_value, 20)
-	if(powerfactor_value > 10)
-		powerfactor_value /= 5
+	if(powerfactor_value > 4)
+		powerfactor_value = 4
 	else if(powerfactor_value > 0)
 		explosion_throw(severity, direction)
 


### PR DESCRIPTION
## `Основные изменения`

**Предпосылка**
Сейчас есть неадекватный перекос длительности слоудауна у взрывов средней мощности, особенно заметно по пику, на котором находится ХЕ трубы, которая накидывает адский слоудаун на 15-20 секунд. Слегка более сильные взрывы имеют ЗНАЧИТЕЛЬНО более низкий слоудаун, серьёзно более сильные взрывы всё ещё не дотягивают и до половину от того, что делают средней силы взрывы. Сам перекос кажется крайне кривым, а сила эффекта ХЕ трубы это полнейший бред.

**Демонстрация ситуации на графике**
(надеюсь не обкакался)
![image](https://github.com/user-attachments/assets/2253ceed-5d9d-4671-83ff-890ba25f5ec7)

Здесь видно, что даже без прямого попадания, а значит с меньшей силой взрыва всё ещё ужас, больше видосов кидал в дискорде, большая часть просто не помещается в ПР из-за размера.
https://github.com/user-attachments/assets/3e3831fa-1461-4916-9741-5b1fe6c7411c

**Что предлагаю**
![image](https://github.com/user-attachments/assets/39b64a62-7699-4acd-9d46-bd6eb7fbb988)
ПР добавляет кап влияния силы взрыва на слоудаун, убирая аномальный разрыв, но не ослабляя сильные взрывы. Труба становится более адекватной. **Взрывы средней силы больше не замедляет сильнее, чем сильные взрыва (хе трубы и хе арты стали замедлять значительно меньше, садар больше, часть ракет каса и шахидка получили небольшую прибавку к замедлению).** В целом слоудауны от трубы, каса, арты и других источников относительно сильного взрыва будут терять прям ощутимый эффект через 4-5 секунд, окончательно пропадать через секунд 8-10.


Слоудаун от трубы не такой шизовый
https://github.com/user-attachments/assets/97eaebb4-7366-4c4b-acbd-0638e1c05169

Примерно так выглядит слоудаун от каса
https://github.com/user-attachments/assets/53dbe643-b6f3-4e56-a814-734df802d3b4

**Технические вопросы**
Явно нужно будет как следует отследить всё это в тестмердже, не уверен, что чёт не сломается, учитывая насколько это кривая формула
Также хотел сделать всё же через max(powerfactor_value, 4), но тогда нужно убирать проверку >0, а я чёт не уверен, что стоит это трогать, не по приколу же оно там. 

## `Как это улучшит игру`

Более логичное влияние силы взрыва на слоудаун, нет возможности навесить сильный слоудаун на 15 секунд на любого ксена, включая т4
## `Ченджлог`
```
:cl:
balance: Взрывы средней силы больше не замедляет сильнее, чем сильные взрыва (хе трубы и хе арты стали замедлять значительно меньше, садар больше, часть ракет каса и шахидка получили небольшую прибавку к замедлению)
/:cl:
```
