### PR TITLE
Укреплённый пол больше не удаляет пол до базового тюрфа

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -100,5 +100,5 @@
 	if(!use(2))
 		to_chat(user, span_warning("You need more rods."))
 		return
-	T.ChangeTurf(/turf/open/floor/engine)
+	T.PlaceOnTop(/turf/open/floor/engine)
 	playsound(src, 'sound/items/deconstruct.ogg', 25, 1)


### PR DESCRIPTION
## `Основные изменения`
Разбор укрепленного железными прутьями пола на шаттле теперь не оставляет после себя тайл космоса.
## `Ченджлог`
```
:cl:
fix: Разбор укрепленного железными прутьями пола на шаттле теперь не оставляет после себя тайл космоса.
/:cl:
```
