### PR TITLE
Medevac animation and cooldown

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 
 //MEDEVAC DEFINES
 #define MEDEVAC_COOLDOWN 1500 //150 seconds or 2,5 minutes aka 2 minutes and 30 secs
+#define MEDEVAC_FULTON_COOLDOWN 1200 //120 seconds or 2 minutes
 #define MEDEVAC_TELE_DELAY 50 // 5 seconds
 //Sentry defines
 #define SENTRY_ALERT_AMMO 1

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -457,7 +457,7 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	var/area/evac_area = get_area(src)
 	if(evac_area.ceiling == CEILING_NONE) // animation evacuation if it havn't roof
 		flick("winched_stretcher",src)
-		last_teleport = world.time + MEDEVAC_FULTON_COOLDOWN
+		last_teleport = world.time + MEDEVAC_FULTON_COOLDOWN // less cooldown if teleported outside.
 		return
 	last_teleport = world.time + MEDEVAC_COOLDOWN
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -454,6 +454,11 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	playsound(linked_beacon.loc,'sound/effects/phasein.ogg', 50, FALSE)
 
 	linked_beacon.medvac_alert(M) //We warn med channel about the mob, not what was teleported.
+	var/area/evac_area = get_area(src)
+	if(evac_area.ceiling == CEILING_NONE) // animation evacuation if it havn't roof
+		flick("winched_stretcher",src)
+		last_teleport = world.time + MEDEVAC_FULTON_COOLDOWN
+		return
 	last_teleport = world.time + MEDEVAC_COOLDOWN
 
 /obj/structure/bed/medevac_stretcher/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## `Основные изменения`
При телепортации вне зданий медэваком происходит мини анимация и у эвака становится чуть меньше кд.
## `Как это улучшит игру`
https://github.com/user-attachments/assets/6870ff3a-d7b3-4f80-9c4e-af9ec1a02ad1
## `Ченджлог`
```
:cl:
balance: При телепортации медэвком вне зданий КД на 30 секунд меньше.
image: При телепортации медэвком вне зданий происходит анимация.
/:cl:
```
