### PR TITLE
Warding Pheromones rework

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -202,7 +202,7 @@
 	else
 		damage = victim.modify_by_armor(damage, blocked, penetration, def_zone)
 
-	if(victim.protection_aura)
+	if(victim.protection_aura) //MARKER
 		damage = round(damage * ((20 - victim.protection_aura) / 20))
 
 	if(!damage)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -202,7 +202,7 @@
 	else
 		damage = victim.modify_by_armor(damage, blocked, penetration, def_zone)
 
-	if(victim.protection_aura) //MARKER
+	if(victim.protection_aura)
 		damage = round(damage * (1 - victim.protection_aura*0.05)) //10% for SLs, 15% for commanders
 
 	if(!damage)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -203,7 +203,7 @@
 		damage = victim.modify_by_armor(damage, blocked, penetration, def_zone)
 
 	if(victim.protection_aura) //MARKER
-		damage = round(damage * ((20 - victim.protection_aura) / 20))
+		damage = round(damage * (1 - victim.protection_aura*0.05)) //10% for SLs, 15% for commanders
 
 	if(!damage)
 		return FALSE

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -66,7 +66,7 @@
 				painloss += O.damage * 1.5
 
 		if(M.protection_aura)
-			painloss -= 20 + M.protection_aura * 20 //-40 pain for SLs, -80 for Commanders
+			painloss -= 20*(1 + M.protection_aura) //-60 pain for SLs, -80 for Commanders
 
 	painloss += reagent_pain_modifier
 

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -66,7 +66,7 @@
 				painloss += O.damage * 1.5
 
 		if(M.protection_aura)
-			painloss -= 20*(1 + M.protection_aura) //-60 pain for SLs, -80 for Commanders
+			painloss -= 20 * (1 + M.protection_aura) //-60 pain for SLs (2-1+1), -80 for Commanders (3-1+1)
 
 	painloss += reagent_pain_modifier
 

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -6,7 +6,6 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/modify_by_armor(damage_amount, armor_type, penetration, def_zone, attack_dir)
-	//Warding pheromones used to change soft armor, but now change the damage directly in apply_damage
 	var/hard_armor_remaining = get_hard_armor(armor_type, def_zone)
 
 	var/effective_penetration = max(0, penetration - hard_armor_remaining)
@@ -69,8 +68,7 @@
 
 	// WARDING PHEROMONES EFFECT
 	if(warding_aura)
-		var/effect_per_aura_level = 0.03 // %damage decrease per level. Max base level is 6, but can be increases from upgrades
-		damage = damage * (1 - warding_aura*effect_per_aura_level)
+		damage = damage * (1 - warding_aura*0.03) // %damage decrease per level. Max base level is 6 (king)
 
 	if(!damage) //no damage
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -68,7 +68,7 @@
 
 	// WARDING PHEROMONES EFFECT
 	if(warding_aura)
-		damage = damage * (1 - warding_aura*0.03) // %damage decrease per level. Max base level is 6 (king)
+		damage *= (1 - warding_aura*0.03) // %damage decrease per level. Max base level is 6 (king)
 
 	if(!damage) //no damage
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -6,6 +6,7 @@
 	return ..()
 
 /mob/living/carbon/xenomorph/modify_by_armor(damage_amount, armor_type, penetration, def_zone, attack_dir)
+	//Warding pheromones used to change soft armor, but now change the damage directly in apply_damage
 	var/hard_armor_remaining = get_hard_armor(armor_type, def_zone)
 
 	var/effective_penetration = max(0, penetration - hard_armor_remaining)
@@ -65,6 +66,11 @@
 		damage -= clamp(damage * (blocked - penetration) * 0.01, 0, damage)
 	else
 		damage = modify_by_armor(damage, blocked, penetration, def_zone)
+
+	// WARDING PHEROMONES EFFECT
+	if(warding_aura)
+		var/effect_per_aura_level = 0.03 // %damage decrease per level. Max base level is 6, but can be increases from upgrades
+		damage = damage * (1 - warding_aura*effect_per_aura_level)
 
 	if(!damage) //no damage
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -68,7 +68,7 @@
 
 	// WARDING PHEROMONES EFFECT
 	if(warding_aura)
-		damage *= (1 - warding_aura*0.03) // %damage decrease per level. Max base level is 6 (king)
+		damage *= (1 - warding_aura*0.025) // %damage decrease per level. Max base level is 6 (king)
 
 	if(!damage) //no damage
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -68,7 +68,7 @@
 
 	// WARDING PHEROMONES EFFECT
 	if(warding_aura)
-		damage *= (1 - warding_aura*0.025) // %damage decrease per level. Max base level is 6 (king)
+		damage *= (1 - warding_aura * 0.025) // %damage decrease per level. Max base level is 6 (king)
 
 	if(!damage) //no damage
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -165,11 +165,7 @@
 		set_frenzy_aura(received_auras[AURA_XENO_FRENZY] || 0)
 
 	if(warding_aura != (received_auras[AURA_XENO_WARDING] || 0))
-		if(warding_aura) //If either the new or old warding is 0, we can skip adjusting armor for it.
-			soft_armor = soft_armor.modifyAllRatings(-warding_aura * 2.5)
 		warding_aura = received_auras[AURA_XENO_WARDING] || 0
-		if(warding_aura)
-			soft_armor = soft_armor.modifyAllRatings(warding_aura * 2.5)
 
 	recovery_aura = received_auras[AURA_XENO_RECOVERY] || 0
 


### PR DESCRIPTION
## `Основные изменения`

### `Идея`
Теперь зеленые феромоны работают как защитный приказ людей.

Приказ людей: у СЛа сила 3-1=2, у ФК 4-1=3. То есть СЛ режет входящий урон на 10%. ФК режет на 15%.
![image](https://github.com/user-attachments/assets/d9a8a0f7-e850-4e63-848a-bf6479558320)

### `Результат`
Сделаем таже для беносов. Каждый уровень феромонов НЕ влияет на софт армор, и понижает финальный урон на X% за уровень.

![image](https://github.com/user-attachments/assets/840c52c5-f0dc-40a0-aa1c-27afec8eca13)


## `Как это улучшит игру`

- Нет дикого разброса эффективности патронов
- Понятно
- Проще балансить и маров и ксен

## `Ченджлог`
```
:cl:qwerty4429
balance: Феромоны защиты дают мультипликативную защиту
/:cl:
```

## `Калькуляции`
 Сейчас феры короля дают 15 софт армора, будут давать 15% просто мультипликативного.
 
![image](https://github.com/user-attachments/assets/408fa627-217d-4bc7-aa2a-e1bd435a740a)
![image](https://github.com/user-attachments/assets/3d2af7f1-38ff-40b4-ae26-78e01aa1c4f1)
![image](https://github.com/user-attachments/assets/28f160f4-44a9-4fe4-895e-94cae3bdd50c)



