### PR TITLE
Фикс слоудауна для даунов

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -44,8 +44,8 @@
 
 	var/powerfactor_value = round(severity * 0.05, 1)
 	powerfactor_value = min(powerfactor_value, 20)
-	if(powerfactor_value > 10)
-		powerfactor_value /= 5
+	if(powerfactor_value > 4)
+		powerfactor_value = 4
 	else if(powerfactor_value > 0)
 		explosion_throw(severity, direction)
 


### PR DESCRIPTION
## `Основные изменения`

Фикс расчета слоудауна от взрывов. Сейчас он считается неправильно (график ниже)
![397958762-2253ceed-5d9d-4671-83ff-890ba25f5ec7](https://github.com/user-attachments/assets/a69dde46-e7f1-49b5-b70a-fdf2c5a24b3a)

Фикс оставит самые сильные взрывы сильными, и пофиксит расчет для слабых.

## `Как это улучшит игру`

- Простая формула
- Логичные эффекты взрывов

## `Ченджлог`
```
:cl: qwerty4429
fix: Слабые взрывы накладывают корректное замедление
/:cl:
```
