### PR TITLE
Tweaks xenomorph explosion formula. Readds multinade launcher to vendors. Lowers its price.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -114,6 +114,7 @@
 		),
 		"Гранаты" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = 4,
+			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = 2,
 			/obj/item/weapon/gun/rifle/tx54 = 2,
 			/obj/item/ammo_magazine/rifle/tx54 = 10,
 			/obj/item/ammo_magazine/rifle/tx54/incendiary = 4,
@@ -355,6 +356,7 @@
 		),
 		"Гранаты" = list(
 			/obj/item/weapon/gun/grenade_launcher/single_shot = 4,
+			/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded = 2,
 			/obj/item/explosive/grenade = 50,
 			/obj/item/explosive/grenade/m15 = 10,
 			/obj/item/explosive/grenade/sticky = 25,

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -37,23 +37,18 @@
 		create_shrapnel(oldloc, rand(16, 24), direction, shrapnel_type = /datum/ammo/bullet/shrapnel/light/xeno)
 		return
 
-	var/sunder_amount = severity * modify_by_armor(1, BOMB) / 8
-
 	apply_damages(severity * 0.5, severity * 0.5, blocked = BOMB, updating_health = TRUE)
+
+	var/sunder_amount = severity * modify_by_armor(1, BOMB) * 0.125
 	adjust_sunder(sunder_amount)
 
-	var/powerfactor_value = round(severity * 0.05, 1)
-	powerfactor_value = min(powerfactor_value, 20)
-	if(powerfactor_value > 10)
-		powerfactor_value /= 5
-	else if(powerfactor_value > 0)
-		explosion_throw(severity, direction)
+	explosion_throw(severity, direction)
 
+	var/powerfactor_value = min(round(severity * 0.01, 1), 10)
 	if(mob_size < MOB_SIZE_BIG)
-		adjust_slowdown(powerfactor_value / 3)
-		adjust_stagger(powerfactor_value * 0.5)
-	else
-		adjust_slowdown(powerfactor_value / 3)
+		adjust_stagger(powerfactor_value SECONDS * 0.5)
+	adjust_slowdown(powerfactor_value)
+
 	TIMER_COOLDOWN_START(src, COOLDOWN_MOB_EX_ACT, 0.1 SECONDS) // this is to prevent x2 damage from mob getting thrown into the explosions wave
 
 /mob/living/carbon/xenomorph/apply_damage(damage = 0, damagetype = BRUTE, def_zone, blocked = 0, sharp = FALSE, edge = FALSE, updating_health = FALSE, penetration)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -39,12 +39,12 @@
 
 	apply_damages(severity * 0.5, severity * 0.5, blocked = BOMB, updating_health = TRUE)
 
-	var/sunder_amount = severity * modify_by_armor(1, BOMB) * 0.125
+	var/sunder_amount = modify_by_armor(severity, BOMB) * 0.125
 	adjust_sunder(sunder_amount)
 
 	explosion_throw(severity, direction)
 
-	var/powerfactor_value = severity * modify_by_armor(1, BOMB) * 0.01
+	var/powerfactor_value = modify_by_armor(severity, BOMB) * 0.01
 	if(mob_size < MOB_SIZE_BIG)
 		adjust_stagger(powerfactor_value SECONDS * 0.5)
 	adjust_slowdown(powerfactor_value)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -44,7 +44,7 @@
 
 	explosion_throw(severity, direction)
 
-	var/powerfactor_value = min(round(severity * 0.01, 1), 10)
+	var/powerfactor_value = severity * modify_by_armor(1, BOMB) * 0.01
 	if(mob_size < MOB_SIZE_BIG)
 		adjust_stagger(powerfactor_value SECONDS * 0.5)
 	adjust_slowdown(powerfactor_value)

--- a/code/modules/reqs/supplypacks/launchers.dm
+++ b/code/modules/reqs/supplypacks/launchers.dm
@@ -130,4 +130,4 @@
 /datum/supply_packs/launchers/multinade_launcher
 	name = "GL-70 grenade launcher"
 	contains = list(/obj/item/weapon/gun/grenade_launcher/multinade_launcher/unloaded)
-	cost = 450
+	cost = 300


### PR DESCRIPTION
## `Основные изменения`
Формула накладывания дебаффов от взрывов на ксеносов была переделана для лучшего различия между слабыми и сильными взрывами и учёта брони ксеносов.
Взрывы теперь стаггерят ксеносов, так как это было задумано.
Взрывы теперь всегда отбрасывают ксеносов.

Многозарядный гранатомёт добавлен в 2-ух экземплярах в оружейный вендор.
Многозарядному гранатомёту снижена цена в карго 450 > 300.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
До этого было приблизительно следующим образом: 
У м15 гранаты сила взрыва 125, что при умножении на 0.05 равно 6 с учётом округления, далее для замедления это делилось на 3, и так как замедление снимается по 0.4 в тик, то получалось 5 тиков замедления с обычной гранаты.
У ракеты банши сила взрыва 320, что давало 16, и из-за того что это число больше 10, оно делилось на 5, из-за чего мы получаем 3.2, делим на 3, и получаем 3 тика замедления, что при отличающейся силе взрыва имеет прямо противоположные своему урону кол-во дебаффов.

Сейчас будет выглядеть следующим образом:
М15, сила взрыва 125, модификация за счёт брони, умножается на 0.01, при делении на 0.4 даёт 3 тика замедления.
Банши, сила взрыва 320, модификация за счёт брони, умножается на 0.01, при делении на 0.4 даёт 8 тиков.
Модификация за счёт брони означает что на дефендере и руне дебаффы будут иметь разную длительность за счёт бомб армора, и у того же кинга при полном сандере замедление не будет накладываться.

Стаггер и отбрасывание в коде были, но почти никогда не случались из-за недочётов формулы.

Вернул многозарядные гранатомёты в вендоры, так как мои прогнозы на его счёт были по большей части сделаны до финальной версии этой формулы, условия отличались весьма разительно, и они соответственно не оправдались.

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
balance: Формула накладывания дебаффов от взрывов на ксеносов была переделана для лучшего различия между слабыми и сильными взрывами и учёта брони ксеносов.
balance: Взрывы теперь стаггерят ксеносов, так как это было задумано.
balance: Взрывы теперь всегда отбрасывают ксеносов.
balance: Многозарядный гранатомёт добавлен в 2-ух экземплярах в оружейный вендор.
balance: Многозарядному гранатомёту снижена цена в карго 450 > 300.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
