### PR TITLE
Updates tgs commands returning strings instead of `tgs_message_content`

### DIFF
--- a/code/modules/admin/verbs/chat_commands.dm
+++ b/code/modules/admin/verbs/chat_commands.dm
@@ -5,21 +5,18 @@
 	help_text = "Gets the playercount, gamemode, and address of the server"
 	var/last_tgs_check = 0
 
-
 /datum/tgs_chat_command/tgscheck/Run(datum/tgs_chat_user/sender, params)
 	var/rtod = REALTIMEOFDAY
 	if(rtod - last_tgs_check < TGS_STATUS_THROTTLE)
 		return
 	last_tgs_check = rtod
 	var/server = CONFIG_GET(string/server)
-	return "Round ID: [GLOB.round_id] | Round Time: [gameTimestamp("hh:mm")] | Players: [length(GLOB.clients)] | Ground Map: [length(SSmapping.configs) ? SSmapping.configs[GROUND_MAP].map_name : "Loading..."] | Ship Map: [length(SSmapping.configs) ? SSmapping.configs[SHIP_MAP].map_name : "Loading..."] | Mode: [GLOB.master_mode] | Round Status: [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] | Link: [server ? server : "<byond://[world.internet_address]:[world.port]>"]"
-
+	return new /datum/tgs_message_content("Round ID: [GLOB.round_id] | Round Time: [gameTimestamp("hh:mm")] | Players: [length(GLOB.clients)] | Ground Map: [length(SSmapping.configs) ? SSmapping.configs[GROUND_MAP].map_name : "Loading..."] | Ship Map: [length(SSmapping.configs) ? SSmapping.configs[SHIP_MAP].map_name : "Loading..."] | Mode: [GLOB.master_mode] | Round Status: [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] | Link: [server ? server : "<byond://[world.internet_address]:[world.port]>"]")
 
 /datum/tgs_chat_command/ahelp
 	name = "ahelp"
 	help_text = "<ckey|ticket #> <message|ticket <close|resolve|icissue|reject|reopen|tier <ticket #>|list>>"
 	admin_only = TRUE
-
 
 /datum/tgs_chat_command/ahelp/Run(datum/tgs_chat_user/sender, params)
 	var/list/all_params = splittext(params, " ")
@@ -37,12 +34,10 @@
 	var/res = TgsPm(target, all_params.Join(" "), sender.friendly_name)
 	return res
 
-
 /datum/tgs_chat_command/namecheck
 	name = "namecheck"
 	help_text = "Returns info on the specified target"
 	admin_only = TRUE
-
 
 /datum/tgs_chat_command/namecheck/Run(datum/tgs_chat_user/sender, params)
 	params = trim(params)
@@ -52,22 +47,18 @@
 	message_admins("Name checking [params] from [sender.friendly_name]")
 	return keywords_lookup(params, TRUE)
 
-
 /datum/tgs_chat_command/adminwho
 	name = "adminwho"
 	help_text = "Lists administrators currently on the server"
 	admin_only = TRUE
 
-
 /datum/tgs_chat_command/adminwho/Run(datum/tgs_chat_user/sender, params)
 	return tgsadminwho()
-
 
 /datum/tgs_chat_command/sdql
 	name = "sdql"
 	help_text = "Runs an SDQL query"
 	admin_only = TRUE
-
 
 /datum/tgs_chat_command/sdql/Run(datum/tgs_chat_user/sender, params)
 	var/list/results = HandleUserlessSDQL(sender.friendly_name, params)
@@ -78,19 +69,16 @@
 	var/list/names = results[5]
 	. = "[text_res.Join("\n")][length(refs) ? "\nRefs: [refs.Join(" ")]" : ""][length(names) ? "\nText: [replacetext(names.Join(" "), "<br>", "")]" : ""]"
 
-
 /datum/tgs_chat_command/reload_admins
 	name = "reload_admins"
 	help_text = "Forces the server to reload admins."
 	admin_only = TRUE
 
-
 /datum/tgs_chat_command/reload_admins/Run(datum/tgs_chat_user/sender, params)
 	ReloadAsync()
 	log_admin("[sender.friendly_name] reloaded admins via chat command.")
 	message_admins("[sender.friendly_name] reloaded admins via chat command.")
-	return "Admins reloaded."
-
+	return new /datum/tgs_message_content("Admins reloaded.")
 
 /datum/tgs_chat_command/reload_admins/proc/ReloadAsync()
 	set waitfor = FALSE
@@ -101,10 +89,9 @@
 	help_text = "Checks current time dilation on the server"
 	var/last_tgs_check = 0
 
-
 /datum/tgs_chat_command/lagcheck/Run(datum/tgs_chat_user/sender, params)
 	var/rtod = REALTIMEOFDAY
 	if(rtod - last_tgs_check < TGS_STATUS_THROTTLE)
 		return
 	last_tgs_check = rtod
-	return "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
+	return new /datum/tgs_message_content("Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")


### PR DESCRIPTION
## `Основные изменения`
Команды теперь возвращают не стринги а `tgs_message_content`
## `Как это улучшит игру`
![image](https://github.com/user-attachments/assets/56b2c945-0ce5-4098-a2c7-a7f3f9313ebc)
## `Ченджлог`
```
:cl:
code: Команды теперь возвращают не стринги а tgs_message_content
/:cl:
```
