### PR TITLE
Icy Caves fixes & rebalance

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -821,9 +821,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"ep" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/rock)
 "eq" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/power/apc/drained,
@@ -958,9 +955,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
-"eQ" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/rock)
 "eS" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -1030,7 +1024,6 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "ff" = (
-/obj/structure/rack,
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -1252,9 +1245,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
-"hi" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/caves/rock)
 "hk" = (
 /obj/machinery/light{
 	dir = 8
@@ -1268,7 +1258,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
 "hq" = (
-/obj/machinery/miner/damaged,
+/obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "hr" = (
@@ -1329,7 +1319,7 @@
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/outside)
 "hP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1402,10 +1392,6 @@
 "ic" = (
 /turf/closed/wall/prison,
 /area/icy_caves/caves/cavesbrig)
-"id" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "if" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1428,10 +1414,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"ij" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
 "il" = (
 /obj/structure/table/reinforced/prison,
 /turf/open/floor/prison,
@@ -1482,10 +1464,6 @@
 /obj/item/reagent_containers/food/snacks/pastries/applecakeslice,
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
-"iw" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/icy_caves/outpost/dorms)
 "ix" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -1606,7 +1584,6 @@
 /turf/open/floor/tile/purple/whitepurplefull,
 /area/icy_caves/caves/northwestmonorail/medbay)
 "jg" = (
-/obj/structure/table/woodentable,
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/random/misc/plushie,
@@ -2146,7 +2123,7 @@
 	},
 /area/icy_caves/caves/cavesbrig)
 "mo" = (
-/obj/machinery/miner/damaged/platinum,
+/obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
 "mp" = (
@@ -2217,9 +2194,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ2)
-"mH" = (
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/LZ2)
 "mK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -2252,11 +2226,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "mX" = (
 /obj/machinery/light{
 	dir = 4
@@ -2277,8 +2246,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
 "ne" = (
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/caves/northern)
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "nf" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -2377,13 +2347,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"nA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/east)
 "nC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/red{
@@ -2640,7 +2603,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/outside)
 "pe" = (
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -2749,10 +2712,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
-"pD" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/dorms)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -2872,12 +2831,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/refinery)
-"qf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/outpost/outside)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -3033,14 +2986,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"qT" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	name = "\improper Dormitories Bedroom"
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/icy_caves/outpost/dorms)
 "qU" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -3527,7 +3472,6 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
 "sL" = (
-/obj/structure/table/woodentable,
 /obj/item/tool/kitchen/knife/ritual,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/cult,
@@ -3854,10 +3798,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"up" = (
-/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/hallway)
 "uq" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -4137,11 +4077,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"vG" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/dorms)
 "vH" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/prison/red{
@@ -4234,6 +4169,9 @@
 /area/icy_caves/outpost/dorms)
 "wh" = (
 /obj/structure/morgue/crematorium,
+/obj/machinery/crema_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/morgue)
 "wi" = (
@@ -4400,7 +4338,7 @@
 "wY" = (
 /obj/effect/spawner/random/weaponry/gun,
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/south)
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -4459,9 +4397,6 @@
 /obj/item/storage/box/lightstick/red,
 /obj/item/storage/box/lightstick,
 /obj/item/storage/box/lightstick,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/hallway)
 "xp" = (
@@ -5319,7 +5254,7 @@
 	dir = 2
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/hallway)
+/area/icy_caves/caves/northwestmonorail/morgue)
 "BQ" = (
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
@@ -5570,7 +5505,7 @@
 /turf/open/floor/tile/dark/green2{
 	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/south)
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -5802,12 +5737,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
-"En" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
 "Eo" = (
 /turf/open/floor/tile/dark/green2{
 	dir = 9
@@ -5953,8 +5882,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "Fe" = (
-/obj/structure/table/gamblingtable,
 /obj/effect/spawner/random/weaponry/gun,
+/obj/structure/table/gamblingtable,
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
 "Ff" = (
@@ -6219,10 +6148,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"Gl" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/LZ2)
 "Gm" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -6253,7 +6178,6 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Gq" = (
-/obj/structure/table/woodentable,
 /obj/item/storage/bible/booze,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/spawner/random/weaponry/gun,
@@ -6654,11 +6578,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
-"Ir" = (
-/obj/machinery/light,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/dorms)
 "Is" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -7276,9 +7195,6 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/garage)
-"Lv" = (
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/outside)
 "Lw" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/plating/plating_catwalk,
@@ -7410,9 +7326,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
-"LY" = (
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/outpost/outside)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7459,8 +7372,12 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "Ml" = (
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "Mm" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -7726,9 +7643,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
 "NI" = (
-/obj/effect/spawner/random/engineering/pickaxe,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/rock)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northwestmonorail/medbay)
 "NJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -7890,10 +7806,8 @@
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
 /obj/item/clothing/head/fedora,
-/obj/structure/cable,
-/obj/machinery/power/apc/drained,
 /turf/open/floor/wood,
-/area/icy_caves/outpost/outside/center)
+/area/icy_caves/outpost/dorms)
 "Ov" = (
 /obj/item/ammo_casing,
 /obj/item/ammo_magazine/smg/m25,
@@ -7987,7 +7901,7 @@
 /turf/open/floor/tile/dark/red2{
 	dir = 8
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/outside)
 "OU" = (
 /obj/structure/sign/double/barsign/carp,
 /turf/closed/mineral/smooth/darkfrostwall,
@@ -8150,11 +8064,11 @@
 /turf/open/floor/wood,
 /area/icy_caves/caves/underground_cafeteria)
 "PX" = (
-/obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
 /obj/item/tool/pen/blue{
 	pixel_x = 5
 	},
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "PY" = (
@@ -8201,7 +8115,7 @@
 "Qi" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/LZ1)
+/area/icy_caves/caves/rock)
 "Qj" = (
 /obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
 /turf/open/floor/tile/dark,
@@ -8465,14 +8379,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/morgue)
 "Ru" = (
-/obj/structure/table/woodentable,
 /obj/effect/spawner/random/misc/paperbin,
 /obj/item/tool/stamp,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"Rv" = (
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves)
 "Rx" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/blood,
@@ -8540,9 +8451,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"RU" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/caves/east)
 "RX" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8640,9 +8548,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/caves)
-"SE" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/outpost/outside)
 "SF" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -8713,12 +8618,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"Tf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/outpost/LZ1)
 "Tg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8755,7 +8654,7 @@
 /turf/open/floor/tile/dark/green2{
 	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/area/icy_caves/caves/south)
 "Tq" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/structure/cable,
@@ -8825,9 +8724,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/alienstuff)
 "TH" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/outside/center)
 "TL" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -8928,7 +8827,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/rock)
 "Ul" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -8939,9 +8838,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail/breakroom)
-"Uo" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/caves/rock)
 "Up" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -9086,7 +8982,7 @@
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
+/area/icy_caves/caves/rock)
 "Ve" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -9273,7 +9169,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northwestmonorail/hallway)
+/area/icy_caves/caves/northwestmonorail/morgue)
 "VT" = (
 /obj/structure/barricade/metal{
 	dir = 1
@@ -9319,9 +9215,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northwestmonorail)
-"We" = (
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/outside/center)
 "Wf" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/tile/dark,
@@ -9398,7 +9291,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
+/area/icy_caves/caves/rock)
 "Wx" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/caves/west)
@@ -9502,6 +9395,9 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Xc" = (
@@ -9577,7 +9473,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
+/area/icy_caves/caves/rock)
 "Xp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9703,10 +9599,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"XT" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/outside)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -9761,9 +9653,6 @@
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/security)
-"Yf" = (
-/turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -9803,7 +9692,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/bluefrostwall,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/caves/rock)
 "Yu" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/weapon_vault)
@@ -9819,7 +9708,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
+/area/icy_caves/caves/rock)
 "Yy" = (
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2{
@@ -9890,7 +9779,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northwestmonorail/hallway)
+/area/icy_caves/caves/northwestmonorail/medbay)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -10109,7 +9998,7 @@
 "ZY" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/smooth/darkfrostwall,
-/area/icy_caves/caves)
+/area/icy_caves/caves/rock)
 "ZZ" = (
 /obj/structure/morgue{
 	dir = 2
@@ -10712,7 +10601,7 @@ Ww
 ZP
 ZP
 ZP
-Rv
+TM
 Zk
 Zm
 UE
@@ -11559,13 +11448,13 @@ vk
 vk
 Nb
 Pp
-vk
-up
-Nb
+ls
+Wf
+NI
 YP
-up
-vk
-vk
+Wf
+ls
+ls
 vk
 vk
 vk
@@ -11644,7 +11533,7 @@ pR
 pR
 ZP
 ZP
-Tf
+Ww
 TM
 bU
 uw
@@ -11800,7 +11689,7 @@ pR
 pR
 pR
 ZP
-qf
+Ww
 TM
 bU
 uw
@@ -12268,7 +12157,7 @@ pR
 pR
 pR
 ZP
-qf
+Ww
 ZP
 XW
 uw
@@ -12424,7 +12313,7 @@ pR
 pR
 ZP
 ZP
-qf
+Ww
 ZP
 XW
 uw
@@ -12486,13 +12375,13 @@ Gx
 qI
 XV
 vk
-vk
-vk
-Nb
+xA
+xA
+Wr
 BO
-vk
+xA
 VS
-vk
+xA
 vk
 vk
 vk
@@ -12977,7 +12866,7 @@ vk
 ZP
 ZP
 ZP
-SR
+ZU
 RL
 ZW
 zB
@@ -13445,7 +13334,7 @@ ZP
 ZP
 ZP
 ZI
-eQ
+ZU
 zB
 ZW
 zB
@@ -13533,7 +13422,7 @@ ZI
 jE
 Zm
 bq
-Ml
+ZP
 UE
 UE
 UE
@@ -13829,8 +13718,8 @@ XO
 XO
 XO
 TT
-XT
-XT
+Qi
+Qi
 TT
 TT
 ZE
@@ -13839,22 +13728,22 @@ HI
 ZE
 ZE
 KJ
-XT
-XT
-XT
-XT
-XT
-XT
-XT
-XT
-XT
-XT
-XT
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
+Qi
 Hl
 Hl
-XT
-XT
-XT
+Qi
+Qi
+Qi
 ZY
 ZY
 ZY
@@ -15161,7 +15050,7 @@ ZI
 ZI
 ZI
 ZP
-im
+gx
 zB
 ZW
 zB
@@ -15316,8 +15205,8 @@ ZI
 ZI
 ZI
 ZI
-SR
-SR
+ZU
+ZU
 zB
 ZW
 zB
@@ -15473,7 +15362,7 @@ ZI
 ZI
 ZI
 ZI
-Zb
+BQ
 zB
 ZW
 Ab
@@ -18123,14 +18012,14 @@ ZI
 ZI
 ZI
 ZI
-id
+JI
 wY
-ZU
-zB
-ZW
-zB
-ZU
-NI
+ym
+Td
+gG
+Td
+ym
+ZJ
 ZI
 ZI
 ZI
@@ -18278,7 +18167,7 @@ dF
 ZP
 ZP
 ZI
-SR
+ym
 ym
 ym
 ym
@@ -18309,19 +18198,19 @@ ev
 wR
 PE
 ZI
-ym
-ym
-ym
-ym
-ym
+ZU
+ZU
+ZU
+ZU
+ZU
 ZP
 ZP
 ZP
 ZP
-ym
-ym
-ym
-ym
+ZU
+ZU
+ZU
+ZU
 ZI
 ZI
 ZI
@@ -18434,7 +18323,7 @@ dF
 dF
 ZP
 ZP
-SR
+ym
 cl
 ym
 ym
@@ -18466,17 +18355,17 @@ rI
 PE
 ZI
 ZI
-ij
-ij
-ij
+SF
+SF
+SF
 ZP
 ZP
 ZP
 ZP
 ZP
 ZP
-ym
-ym
+ZU
+ZU
 ZI
 ZI
 ZI
@@ -18590,7 +18479,7 @@ lK
 dF
 ZP
 ZP
-bl
+cl
 ym
 ym
 ym
@@ -18631,8 +18520,8 @@ ZP
 ZP
 ZP
 ZP
-ym
-ym
+ZU
+ZU
 ZI
 ZI
 ZI
@@ -18786,9 +18675,9 @@ ZP
 ZP
 ZP
 ZP
-ym
-ym
-ym
+ZU
+ZU
+ZU
 ZI
 ZI
 ZI
@@ -18940,7 +18829,7 @@ ym
 ym
 ow
 ZP
-CN
+nL
 ow
 ow
 ow
@@ -19570,7 +19459,7 @@ my
 my
 my
 my
-my
+ne
 my
 my
 my
@@ -19726,7 +19615,7 @@ li
 nZ
 li
 li
-li
+ne
 li
 VC
 li
@@ -19882,7 +19771,7 @@ ow
 nL
 ZI
 mo
-li
+Ml
 ow
 ZI
 ZI
@@ -19928,9 +19817,9 @@ bf
 bf
 Ke
 Fc
-pD
-pD
-vG
+tg
+tg
+tX
 tg
 tg
 tg
@@ -20038,7 +19927,7 @@ ZI
 ZI
 ZI
 ZI
-ow
+nL
 ZI
 ZI
 ZI
@@ -20086,7 +19975,7 @@ tg
 IR
 tg
 tg
-pD
+tg
 tg
 tg
 tg
@@ -20242,7 +20131,7 @@ Lb
 tg
 tg
 tg
-Ir
+PO
 Hf
 Hf
 Hf
@@ -20315,7 +20204,7 @@ gG
 ym
 Be
 ym
-fG
+ym
 ym
 cl
 ZI
@@ -20398,7 +20287,7 @@ Vo
 HW
 tg
 tg
-pD
+tg
 Hf
 RP
 wZ
@@ -20524,7 +20413,7 @@ my
 my
 my
 my
-oN
+my
 Iw
 my
 my
@@ -20554,9 +20443,9 @@ Vo
 Dg
 hK
 tg
-pD
-qT
-iw
+tg
+Zq
+wZ
 wZ
 LC
 ND
@@ -20679,7 +20568,7 @@ DD
 DD
 DD
 DD
-DD
+TH
 my
 li
 li
@@ -20774,7 +20663,7 @@ ZP
 ZP
 ZP
 ZP
-SR
+ym
 ym
 CN
 dS
@@ -21088,7 +20977,7 @@ ZI
 ZI
 ZI
 ZI
-SR
+ym
 ym
 ym
 gG
@@ -21648,7 +21537,7 @@ tg
 tg
 tg
 Hf
-Fy
+PJ
 Fy
 Fa
 ND
@@ -22648,7 +22537,7 @@ ZP
 ZP
 ZP
 ZP
-GH
+fG
 ym
 ym
 gG
@@ -22715,8 +22604,8 @@ li
 li
 li
 li
-We
-We
+ZI
+ZI
 li
 DD
 HA
@@ -22868,11 +22757,11 @@ DD
 HA
 DD
 li
-We
-We
-We
-We
-We
+ZI
+ZI
+ZI
+ZI
+ZI
 li
 li
 HA
@@ -22960,7 +22849,7 @@ ZP
 ZP
 ZP
 ZP
-dF
+CN
 dS
 ym
 gG
@@ -23025,11 +22914,11 @@ HA
 DD
 li
 li
-We
-We
-We
-We
-We
+ZI
+ZI
+ZI
+ZI
+ZI
 li
 HA
 my
@@ -23428,7 +23317,7 @@ oz
 MC
 mf
 ZI
-Zl
+Td
 Td
 fE
 gG
@@ -23465,7 +23354,7 @@ ZP
 ZP
 ZP
 ym
-TH
+fG
 ym
 ym
 ym
@@ -23584,7 +23473,7 @@ iq
 Eq
 mf
 kF
-Zl
+Td
 Td
 Td
 gG
@@ -23740,7 +23629,7 @@ Fn
 aL
 MI
 Da
-Zl
+Td
 Td
 Td
 gG
@@ -23896,7 +23785,7 @@ mN
 Gi
 Az
 Tn
-mV
+eW
 eW
 vF
 iy
@@ -24052,7 +23941,7 @@ XK
 mf
 mf
 kw
-Zl
+Td
 Td
 dH
 gG
@@ -24208,7 +24097,7 @@ XK
 mf
 ZP
 ZP
-Zl
+Td
 Td
 Td
 gG
@@ -24402,19 +24291,19 @@ ic
 ic
 ZI
 ZI
-YT
-YT
-YT
-YT
+ym
+ym
+ym
+ym
 ZI
 ZI
 ZI
 ZI
 ZI
 ZI
-YT
-YT
-YT
+ym
+ym
+ym
 ZI
 ZI
 ZI
@@ -24559,17 +24448,17 @@ ic
 ic
 ZI
 ZI
-YT
-eK
-JD
+ym
+Be
+dT
 ZI
 ZI
 ZI
 ZI
 ZI
-YT
-YT
-YT
+ym
+ym
+ym
 ZI
 ZI
 ZI
@@ -24715,17 +24604,17 @@ Wq
 ic
 ZI
 ZI
-YT
-YT
-YT
-YT
+ym
+ym
+ym
+ym
 ZI
 ZI
 ZI
 ZI
-YT
-YT
-YT
+ym
+ym
+ym
 ZI
 ZI
 ZI
@@ -24832,7 +24721,7 @@ Ju
 mf
 ZP
 ZP
-dF
+dV
 dU
 YT
 Bz
@@ -24872,7 +24761,7 @@ ic
 ZI
 ZI
 ZI
-YT
+ym
 XO
 XO
 pR
@@ -25202,11 +25091,11 @@ XO
 pR
 XO
 XO
-RU
-RU
-RU
-RU
-RU
+XO
+XO
+XO
+XO
+XO
 ZI
 ZI
 ZI
@@ -25360,9 +25249,9 @@ Za
 Za
 oO
 XO
-hi
-hi
-RU
+Za
+Za
+XO
 ZI
 ZI
 ZI
@@ -25503,7 +25392,7 @@ pR
 pR
 pR
 pR
-Uo
+pR
 XO
 XO
 Za
@@ -25513,8 +25402,8 @@ XO
 XO
 XO
 XO
-Uo
-Uo
+pR
+pR
 oO
 Za
 oO
@@ -25656,23 +25545,23 @@ Za
 pR
 pR
 pR
-Uo
 pR
-Uo
-Uo
-Za
-XO
-Uo
+pR
+pR
 pR
 Za
 XO
+pR
+pR
+Za
 XO
-Uo
-Uo
-Uo
-Uo
-Uo
-Uo
+XO
+pR
+pR
+pR
+pR
+pR
+pR
 XO
 oO
 xh
@@ -25796,8 +25685,8 @@ YT
 eK
 YT
 YT
-RU
-RU
+XO
+XO
 ic
 ic
 ic
@@ -25810,26 +25699,26 @@ XO
 XO
 Za
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
 pR
 Za
 XO
-Uo
+pR
 pR
 Za
 Za
 XO
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
+pR
 XO
 Za
 Za
@@ -25953,36 +25842,36 @@ YT
 YT
 dq
 YT
-RU
-RU
-AU
+XO
+XO
+SI
 tu
 OT
 hN
-AU
-RU
+SI
+XO
 XO
 Za
 Za
 XO
 pR
-Uo
-Uo
-Uo
-Uo
-Uo
+pR
+pR
+pR
+pR
+pR
 pR
 Za
 XO
-Uo
-Uo
+pR
+pR
 XO
 Za
 Za
 XO
-Uo
-Uo
-Uo
+pR
+pR
+pR
 XO
 XO
 XO
@@ -26109,13 +25998,13 @@ YT
 eK
 YT
 YT
-RU
-RU
 XO
-AU
-nA
-AU
-RU
+XO
+XO
+SI
+QN
+SI
+XO
 XO
 Za
 Za
@@ -26126,11 +26015,11 @@ pR
 pR
 pR
 pR
-Uo
+pR
 pR
 Za
 XO
-Uo
+pR
 pR
 Za
 Za
@@ -26210,7 +26099,7 @@ ZP
 ZP
 ZI
 ZI
-ne
+ZI
 SR
 bl
 SR
@@ -26271,36 +26160,36 @@ XO
 XO
 pd
 XO
-RU
 XO
 XO
-XO
-XO
-XO
-XO
-pR
-XO
-XO
-XO
-XO
-Za
-Za
-XO
-Uo
-XO
-XO
-XO
-Za
-XO
-Za
-Za
 XO
 XO
 XO
 XO
 XO
 pR
-Uo
+XO
+XO
+XO
+XO
+Za
+Za
+XO
+pR
+XO
+XO
+XO
+Za
+XO
+Za
+Za
+XO
+XO
+XO
+XO
+XO
+pR
+pR
 ZI
 ZI
 Fr
@@ -26390,7 +26279,7 @@ SR
 Zb
 SR
 SR
-eQ
+SR
 ZI
 ZI
 YT
@@ -26422,7 +26311,7 @@ ZP
 dq
 YT
 YT
-SE
+YT
 XO
 np
 QN
@@ -26455,9 +26344,9 @@ Za
 Za
 Za
 Za
-Uo
-Uo
-Uo
+pR
+pR
+pR
 ZI
 tH
 hr
@@ -26469,7 +26358,7 @@ tH
 pR
 pR
 pR
-Gl
+SU
 Yl
 Yl
 Yl
@@ -26611,7 +26500,7 @@ pR
 pR
 Za
 Za
-Uo
+pR
 pR
 pR
 XO
@@ -26625,7 +26514,7 @@ tH
 pR
 pR
 Za
-Gl
+SU
 Yl
 Yl
 Yl
@@ -27479,7 +27368,7 @@ ZI
 ZI
 ZI
 ZI
-GH
+SR
 SR
 SR
 ZI
@@ -27529,8 +27418,8 @@ ZI
 ZI
 ZI
 ZI
-mH
-mH
+ZI
+ZI
 oP
 oP
 oP
@@ -27549,19 +27438,19 @@ nI
 nI
 ZI
 ZI
-Uo
-Uo
-Uo
+nI
+nI
+nI
 oP
 iK
 XO
 XO
 ZI
-ep
+XO
 Za
 XO
 pR
-Gl
+SU
 ZI
 ZI
 ZI
@@ -27685,8 +27574,8 @@ ZI
 ZI
 ZI
 ZI
-mH
-mH
+ZI
+ZI
 on
 on
 on
@@ -27707,12 +27596,12 @@ ZI
 ZI
 ZI
 ZI
-Uo
+nI
 oP
 iK
 XO
 pR
-Lv
+ZI
 XO
 Za
 XO
@@ -27831,7 +27720,7 @@ ZI
 XO
 pR
 XO
-hi
+Za
 Za
 Za
 pR
@@ -27862,13 +27751,13 @@ jW
 ZI
 ZI
 ZI
-Uo
-Uo
+nI
+nI
 oP
 iK
 XO
 XO
-Lv
+ZI
 XO
 XO
 XO
@@ -27992,7 +27881,7 @@ XO
 Za
 XO
 Wu
-hi
+wa
 on
 wa
 wa
@@ -28019,7 +27908,7 @@ ZI
 ZI
 ZI
 ZI
-Uo
+nI
 nI
 Tl
 Za
@@ -28142,7 +28031,7 @@ ZP
 ZP
 pR
 pR
-LY
+ZP
 XO
 XO
 Za
@@ -28298,7 +28187,7 @@ ZP
 ZP
 pR
 pR
-Lv
+ZI
 ZI
 XO
 XO
@@ -28327,8 +28216,8 @@ IT
 on
 on
 on
-mH
-mH
+ZI
+ZI
 ZI
 nI
 nI
@@ -28453,9 +28342,9 @@ ZP
 ZP
 ZP
 pR
-Lv
-Lv
-Lv
+ZI
+ZI
+ZI
 np
 XO
 Za
@@ -28609,8 +28498,8 @@ ZP
 ZP
 ZP
 pR
-LY
-Lv
+ZP
+ZI
 XO
 XO
 XO
@@ -28957,7 +28846,7 @@ oP
 wa
 nI
 nI
-En
+Tl
 ZI
 ZP
 ZP
@@ -29825,7 +29714,7 @@ ZI
 ZP
 ZI
 ZI
-Zl
+AU
 AU
 uz
 AU
@@ -29887,8 +29776,8 @@ zF
 IT
 oP
 nI
-Uo
-Uo
+nI
+nI
 oP
 wa
 oP
@@ -29981,7 +29870,7 @@ ZI
 ZP
 ZI
 KY
-Zl
+AU
 Lk
 Ra
 lb
@@ -30043,9 +29932,9 @@ nl
 Wm
 oP
 wa
-Uo
-Uo
-Uo
+nI
+nI
+nI
 wa
 oP
 ZI
@@ -30197,8 +30086,8 @@ IT
 IT
 yk
 on
-mH
-mH
+ZI
+ZI
 ZI
 ZI
 nI
@@ -30357,7 +30246,7 @@ on
 on
 ZI
 ZI
-mH
+ZI
 on
 ZI
 ZI
@@ -30827,8 +30716,8 @@ sT
 oP
 wa
 sT
-Yf
-Yf
+ZP
+ZP
 Yx
 ZP
 ZP
@@ -30983,8 +30872,8 @@ oP
 oP
 wa
 oP
-Yf
-Yf
+ZP
+ZP
 Yx
 ZP
 ZP
@@ -31139,8 +31028,8 @@ oP
 wa
 wa
 oP
-Yf
-Yf
+ZP
+ZP
 Yx
 ZP
 ZP
@@ -31295,8 +31184,8 @@ td
 wa
 wa
 oP
-Yf
-Yf
+ZP
+ZP
 Yx
 ZP
 ZP
@@ -31451,8 +31340,8 @@ kA
 kA
 jt
 oP
-Yf
-Yf
+ZP
+ZP
 Yx
 ZP
 ZP
@@ -31608,7 +31497,7 @@ tL
 oy
 oP
 nI
-Yf
+ZP
 Yx
 ZP
 ZP
@@ -31764,7 +31653,7 @@ tL
 oy
 wa
 nI
-Yf
+ZP
 Yx
 ZP
 ZP
@@ -31920,7 +31809,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Yx
 ZP
 ZP
@@ -32076,7 +31965,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Yx
 ZP
 ZP
@@ -32232,7 +32121,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Yx
 ZP
 ZP
@@ -32388,7 +32277,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -32544,7 +32433,7 @@ tL
 oy
 wa
 nI
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -32700,7 +32589,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -32856,7 +32745,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -33012,7 +32901,7 @@ tL
 oy
 wa
 oP
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -33168,7 +33057,7 @@ tL
 oy
 oP
 oP
-Yf
+ZP
 Xo
 ZP
 ZP
@@ -33323,8 +33212,8 @@ kB
 kB
 jt
 oP
-Yf
-Yf
+ZP
+ZP
 Xo
 ZP
 ZP
@@ -33479,8 +33368,8 @@ uq
 wa
 oP
 nI
-Yf
-Yf
+ZP
+ZP
 Xo
 ZP
 ZP
@@ -33635,8 +33524,8 @@ oP
 oP
 nI
 on
-Yf
-Yf
+ZP
+ZP
 Xo
 ZP
 ZP
@@ -33766,33 +33655,33 @@ ZP
 Xo
 ZP
 ZP
-mH
-mH
-mH
-mH
-mH
-mH
-mH
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZI
+ZI
+ZI
+ZI
+ZI
+ZI
+ZI
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 Xo
 ZP
 ZP
@@ -33923,32 +33812,32 @@ Xo
 ZP
 ZP
 ZP
-mH
-mH
-mH
-mH
-mH
-mH
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZI
+ZI
+ZI
+ZI
+ZI
+ZI
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 Xo
 ZP
 ZP

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1587,6 +1587,7 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/random/misc/plushie,
+/obj/structure/table/woodentable,
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
 "jk" = (
@@ -3474,6 +3475,7 @@
 "sL" = (
 /obj/item/tool/kitchen/knife/ritual,
 /obj/effect/decal/cleanable/blood,
+/obj/structure/table/woodentable,
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
 "sM" = (
@@ -6181,6 +6183,7 @@
 /obj/item/storage/bible/booze,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/spawner/random/weaponry/gun,
+/obj/structure/table/woodentable,
 /turf/open/floor/cult,
 /area/icy_caves/caves/chapel)
 "Gv" = (


### PR DESCRIPTION
## `Основные изменения`

Починил трубу на восточном ЛЗ, теперь оно играбельно?
Переместил АПЦ центральной улицы из дорм на центральную улицу.
Крематорий теперь можно активировать.
Подредактированы зоны, дыры убраны.
Уменьшил количество буров в пещерах.
Убрал дублирующуюся стойку и лампочку
Четвёртый крашсайт теперь выглядит вот так:
![dreamseeker_JL7bqAF59o](https://github.com/user-attachments/assets/a14cdd34-53ff-42ef-8e1a-20e870dc8273)


## `Как это улучшит игру`

В лучшую сторону.

## `Ченджлог`
```
:cl:
map: На карте Icy Caves были отредактированы зоны. Уменьшено количество буров и изменён четвертый крашсайт для краша.
/:cl:
```
