### PR TITLE
Deletes shitloop of barricades ex_act.

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -150,18 +150,8 @@
 			new stack_type (loc, stack_amt)
 	return ..()
 
-/obj/structure/barricade/ex_act(severity, direction)
-	if(QDELETED(src))
-		return
-	for(var/obj/structure/barricade/barricade in get_step(src, dir)) //discourage double-stacking barricades by removing health from opposing barricade
-		if(barricade.dir != REVERSE_DIR(dir))
-			continue
-		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, ex_act), severity, direction)
-	take_damage(severity, BRUTE, BOMB, attack_dir = direction)
-	update_icon()
-
 /obj/structure/barricade/on_explosion_destruction(severity, direction)
-	create_shrapnel(get_turf(src), rand(2,5), direction, shrapnel_type = /datum/ammo/bullet/shrapnel/light)
+	create_shrapnel(get_turf(src), rand(2, 5), direction, shrapnel_type = /datum/ammo/bullet/shrapnel/light)
 	if(prob(50)) // no message spam pls
 		return
 	visible_message(span_warning("[src] blows apart in the explosion, sending shards flying!"))


### PR DESCRIPTION
## `Основные изменения`
Удалил всратую интеракцию баррикад при взрыве и наличии баррикад на соседних тайлах, которая роняла сервер.
## `Как это улучшит игру`
Меньше роняемого сервера.
## `Ченджлог`
```
:cl:
del: Удалил всратую интеракцию баррикад при взрыве и наличии баррикад на соседних тайлах, которая роняла сервер.
/:cl:
```
