### PR TITLE
Heat rockets now damage sunder, lowers HE rockets sundering.

### DIFF
--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -14,7 +14,6 @@
 	max_range = 14
 	damage = 80
 	penetration = 100
-	sundering = 100
 	bullet_color = LIGHT_COLOR_FIRE
 	barricade_clear_distance = 2
 
@@ -41,7 +40,6 @@
 	max_range = 14
 	damage = 60
 	penetration = 100
-	sundering = 100
 
 /datum/ammo/rocket/he/drop_nade(turf/T)
 	cell_explosion(T, 240, 65)
@@ -60,7 +58,7 @@
 	damage = 340
 	accurate_range = 15
 	penetration = 200
-	sundering = 0
+	sundering = 50
 
 /datum/ammo/rocket/ap/drop_nade(turf/T)
 	cell_explosion(T, 50, 25)
@@ -161,7 +159,6 @@
 	damage = 200
 	penetration = 75
 	max_range = 20
-	sundering = 100
 	///The radius for the non explosion effects
 	var/effect_radius = 3
 
@@ -179,7 +176,6 @@
 	penetration = 25
 	max_range = 30
 	sundering = 2
-
 	///The smoke system that the WP gas uses to spread.
 	var/datum/effect_system/smoke_spread/smoke_system
 
@@ -229,7 +225,6 @@
 	max_range = 30
 	damage = 50
 	penetration = 50
-	sundering = 50
 
 /datum/ammo/rocket/recoilless/drop_nade(turf/T)
 	cell_explosion(T, 200, 70)
@@ -241,7 +236,7 @@
 	flags_ammo_behavior = AMMO_SNIPER
 	damage = 200
 	penetration = 100
-	sundering = 0
+	sundering = 50
 
 /datum/ammo/rocket/recoilless/heat/drop_nade(turf/T)
 	cell_explosion(T, 50, 25)
@@ -281,7 +276,6 @@
 	max_range = 21
 	damage = 10
 	penetration = 0
-	sundering = 0
 	/// Smoke type created when projectile detonates.
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
 	/// Radius this smoke will encompass on detonation.
@@ -324,7 +318,6 @@
 	name = "explosive rocket"
 	damage = 50
 	penetration = 100
-	sundering = 100
 	max_range = 30
 
 /datum/ammo/rocket/oneuse/drop_nade(turf/T)
@@ -372,7 +365,7 @@
 	hud_state = "rpg_heat"
 	damage = 200
 	penetration = 100
-	sundering = 0
+	sundering = 50
 	accuracy = -10 //Not designed for anti human use
 	flags_ammo_behavior = AMMO_SNIPER|AMMO_UNWIELDY
 

--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -460,7 +460,7 @@
 	flags_ammo_behavior = AMMO_TARGET_TURF|AMMO_SNIPER
 	damage = 30
 	penetration = 50
-	sundering = 5
+	sundering = 35
 
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
 	cell_explosion(T, 110, 40)

--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -460,7 +460,7 @@
 	flags_ammo_behavior = AMMO_TARGET_TURF|AMMO_SNIPER
 	damage = 30
 	penetration = 50
-	sundering = 35
+	sundering = 5
 
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
 	cell_explosion(T, 110, 40)

--- a/code/modules/projectiles/ammo_datums/rocket.dm
+++ b/code/modules/projectiles/ammo_datums/rocket.dm
@@ -159,6 +159,7 @@
 	damage = 200
 	penetration = 75
 	max_range = 20
+	sundering = 50
 	///The radius for the non explosion effects
 	var/effect_radius = 3
 

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -149,7 +149,7 @@
 
 /obj/item/ammo_magazine/rocket/sadar/ap
 	name = "\improper 84mm 'L-G' anti-armor rocket"
-	desc = "A tube for an AP rocket, the warhead of which inside is a missile assisted kinetic penetrator that will devastate just about anything that it hits internally, but will do nothing to the surrounding armor. When empty, use this frame to deconstruct it."
+	desc = "A tube for an AP rocket, the warhead of which inside is a missile assisted kinetic penetrator that will devastate just about anything that it hits internally, destroying it's armor in the process. When empty, use this frame to deconstruct it."
 	icon_state = "rocket_ap"
 	default_ammo = /datum/ammo/rocket/ap
 	bonus_overlay = "rocket_ap"
@@ -196,7 +196,7 @@
 
 /obj/item/ammo_magazine/rocket/recoilless/heat
 	name = "\improper 67mm HEAT shell"
-	desc = "A high explosive-anti tank shell for the RL-160 recoilless rifle. Fires a penetrating shot with no explosion. It will do moderate damage to all types of enemies, but does not sunder their armor. Requires specialized storage to carry."
+	desc = "A high explosive-anti tank shell for the RL-160 recoilless rifle. Fires a penetrating shot with no explosion. It will do moderate damage to all types of enemies, sundering their armor. Requires specialized storage to carry."
 	icon_state = "shell_heat"
 	default_ammo = /datum/ammo/rocket/recoilless/heat
 


### PR DESCRIPTION
## `Основные изменения`
Сандер ХЕ ракет 100 >> 0
Сандер ХИАТ ракет 0 >> 50
Сандер фосфорной ракеты для садара 100 >> 50
## `Как это улучшит игру`
ХЕ ракеты наносят некоторый сандер самим взрывом, и то что снаряд расчитанный на доставку взрыв-заряда разрушает оболочкой броню смотрится странно в сравнении ХИАТ ракет, которые эти броню пробивают, и этим урон и наносящие.
Да и ХИАТ ракетам нужен бафф, так как они хлам последний.
Фосфорным ракетам понизил сандер чтобы совпадали с ХИАТ-ами.
## `Ченджлог`
```
:cl:
balance: Сандер ХЕ ракет 100 >> 0
balance: Сандер ХИАТ ракет 0 >> 50
balance: Сандер фосфорной ракеты для садара 100 >> 50
/:cl:
```
