### PR TITLE
Resin huggers no longer stack sticky resin on 1 tile.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -777,13 +777,13 @@
 	if(!combat_hugger_check_target(M))
 		return FALSE
 
-	visible_message(span_danger("[src] explodes into a mess of viscous resin!"))
-	playsound(loc, SFX_ALIEN_RESIN_BUILD, 50, 1)
 	do_attack_animation(M)
 
 	if(have_resin)
+		visible_message(span_danger("[src] explodes into a mess of viscous resin!"))
+		playsound(loc, SFX_ALIEN_RESIN_BUILD, 50, 1)
 		for(var/turf/sticky_tile AS in RANGE_TURFS(1, loc))
-			if(!locate(/obj/effect/xenomorph/spray) in sticky_tile.contents)
+			if(!locate(/obj/alien/resin/sticky) in sticky_tile)
 				new /obj/alien/resin/sticky/thin(sticky_tile)
 		for(var/mob/living/target in range(1, loc))
 			if(isxeno(target)) //Xenos aren't affected by sticky resin
@@ -794,7 +794,9 @@
 		have_resin = FALSE
 	else
 		var/mob/living/victim = M
+		playsound(victim, 'sound/effects/vegetation_hit.ogg', 25, 1)
 		victim.apply_damage(80, STAMINA, BODY_ZONE_HEAD, BIO, updating_health = TRUE) //This should prevent sprinting
+		victim.visible_message(span_danger("[src] hastily claws at [victim]!"), span_danger("[src] hastily claws at you, making you feel weaker!"))
 
 	leaping = FALSE
 	go_idle() //We're a bit slow on the recovery


### PR DESCRIPTION
## `Основные изменения`
Смоляные хаггера больше не стакают липкую резину на одном тайле.
Также добавил свой звук и сообщение для нанесения стамина урона после взрыва липкой резиной.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Смоляные хаггера больше не стакают липкую резину на одном тайле.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
