### PR TITLE
Delete microdosing extra counting towards reagent cap.

### DIFF
--- a/code/modules/organs/organs.dm
+++ b/code/modules/organs/organs.dm
@@ -96,9 +96,9 @@
 	if(SEND_SIGNAL(owner, COMSIG_LIVING_UPDATE_PLANE_BLUR) & COMPONENT_CANCEL_BLUR)
 		medicine_cap += freyr_medicine_cap
 
-	current_medicine_count += new_medicines //We want to include medicines that were individually both added and removed this tick
-	var/overflow = current_medicine_count - medicine_cap  //This catches any case where a reagent was added with volume below its metabolism
-	current_medicine_count -= removed_medicines //Otherwise, you can microdose infinite chems without kidneys complaining
+	current_medicine_count += new_medicines // We detect reagents over the cap, and add punishment for them later
+	current_medicine_count -= removed_medicines // Microdosing isn't accounted for because of how stomach works
+	var/overflow = current_medicine_count - medicine_cap
 
 	new_medicines = 0
 	removed_medicines = 0

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -151,7 +151,7 @@
  * * multiplier - multiplies amount of each reagent by this number
  * * preserve_data - if preserve_data=0, the reagents data will be lost. Usefull if you use data for some strange stuff and don't want it to be transferred.
  * * no_react - passed through to [/datum/reagents/proc/add_reagent]
- * * transfer_to_stomach - does it goes to stomach like from pills and food?
+ * * transfer_to_stomach - does it go to stomach like from pills and food?
  *  */
 /datum/reagents/proc/trans_to(
 	atom/target,


### PR DESCRIPTION
## `Основные изменения`
Микродозинг больше не добавляет +1 реагент к подсчёту реагентов при превышении капа реагентов.
## `Как это улучшит игру`
Я думаю что микродозинг имеет свои плюсы и минусы, поэтому пусть будет альтернативой, для тех кто готов страдать этой фигней.
Также это исправит то что таблетки лишний раз дают мультики при употреблении.
## `Ченджлог`
```
:cl:
balance: Микродозинг больше не добавляет +1 реагент к подсчёту реагентов при превышении капа реагентов.
/:cl:
```
