### PR TITLE
RU keybinds fix

### DIFF
--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -822,7 +822,7 @@
 			if(!params["key"])
 				return
 			var/mods = params["key_mods"]
-			var/full_key = params["key"]
+			var/full_key = convert_ru_key_to_en_key(params["key"])
 			var/Altmod = ("ALT" in mods) ? "Alt" : ""
 			var/Ctrlmod = ("CONTROL" in mods) ? "Ctrl" : ""
 			var/Shiftmod = ("SHIFT" in mods) ? "Shift" : ""


### PR DESCRIPTION
## `Основные изменения`

Бинды работают с русской раскладкой.

## `Как это улучшит игру`

Можно будет не перезаходить в игру с английской раскладкой чтобы поменять бинды, АЛИЛУЯ!!

## `Ченджлог`
```
:cl:
fix: Бинды работают с русской раскладкой.
/:cl:
```
