### PR TITLE
Restricts buying factory equipment on crash.

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -80,6 +80,8 @@
 
 	GLOB.start_squad_landmarks_list = null
 
+	GLOB.all_supply_groups -= "Factory" // In ideal world, we just balance factories out
+
 	for(var/obj/machinery/telecomms/relay/preset/telecomms/relay AS in GLOB.ground_telecomms_relay)
 		qdel(relay) // so there's no double intercomms, hacky, but i don't know a better way.
 

--- a/code/modules/reqs/supplypacks/_supplypacks.dm
+++ b/code/modules/reqs/supplypacks/_supplypacks.dm
@@ -3,7 +3,22 @@
 //NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
-GLOBAL_LIST_INIT(all_supply_groups, list("Operations", "Weapons", "Smartguns", "Stationary", "Launchers", "Explosives", "Armor", "Clothing", "Medical", "Engineering", "Supplies", "Imports", "Vehicles", "Factory"))
+GLOBAL_LIST_INIT(all_supply_groups, list(
+	"Operations",
+	"Weapons",
+	"Smartguns",
+	"Stationary",
+	"Launchers",
+	"Explosives",
+	"Armor",
+	"Clothing",
+	"Medical",
+	"Engineering",
+	"Supplies",
+	"Imports",
+	"Vehicles",
+	"Factory",
+))
 
 /datum/supply_packs
 	var/name

--- a/code/modules/reqs/ui/request.dm
+++ b/code/modules/reqs/ui/request.dm
@@ -1,4 +1,3 @@
-
 /datum/supply_ui/requests
 	tgui_name = "CargoRequest"
 


### PR DESCRIPTION
## `Основные изменения`
На краше теперь нельзя купить оборудование для завода.
## `Как это улучшит игру`
Бесконечные ресурсы за 1600 очков выглядит всрато.
## `Ченджлог`
```
:cl:
balance: На краше теперь нельзя купить оборудование для завода.
/:cl:
```
