### PR TITLE
Miner upgrades now also break upon desroying. Fixes jump to area teleporting user to nullspace without a choice.

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -150,13 +150,14 @@
 /obj/machinery/miner/welder_act(mob/living/user, obj/item/I)
 	. = ..()
 	var/obj/item/tool/weldingtool/weldingtool = I
-	if((miner_status == MINER_RUNNING) && miner_upgrade_type)
-		if(!weldingtool.remove_fuel(2,user))
+	if(miner_status == MINER_RUNNING && miner_upgrade_type)
+		if(!weldingtool.remove_fuel(2, user))
 			to_chat(user, span_info("You need more welding fuel to complete this task!"))
 			return FALSE
 		to_chat(user, span_info("You begin uninstalling the [miner_upgrade_type] from the miner!"))
 		user.visible_message(span_notice("[user] begins dismantling the [miner_upgrade_type] from the miner."))
-		if(!do_after(user, 30 SECONDS, NONE, src, BUSY_ICON_BUILD))
+		var/fumbling_time = 30 SECONDS - 5 SECONDS * user.skills.getRating(SKILL_ENGINEER)
+		if(!do_after(user, fumbling_time, NONE, src, BUSY_ICON_BUILD, extra_checks = CALLBACK(weldingtool, /obj/item/tool/weldingtool/proc/isOn)))
 			return FALSE
 		user.visible_message(span_notice("[user] dismantles the [miner_upgrade_type] from the miner!"))
 		var/obj/item/upgrade
@@ -344,9 +345,20 @@
 		playsound(loc, SFX_ALIEN_CLAW_METAL, 25, TRUE)
 		miner_integrity -= 25
 		set_miner_status()
-		if(miner_status == MINER_DESTROYED && xeno_attacker.client)
-			var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[xeno_attacker.ckey]
-			personal_statistics.miner_sabotages_performed++
+		if(miner_status == MINER_DESTROYED)
+			if(miner_upgrade_type)
+				switch(miner_upgrade_type)
+					if(MINER_RESISTANT)
+						max_miner_integrity = initial(max_miner_integrity)
+					if(MINER_OVERCLOCKED)
+						required_ticks = initial(required_ticks)
+				xeno_attacker.visible_message(span_danger("[xeno_attacker] destroys \the [miner_upgrade_type] upgrade in the process!"), \
+				span_danger("We destroy \the [miner_upgrade_type] upgrade in the process!"), null, 5)
+				miner_upgrade_type = null
+				update_icon()
+			if(xeno_attacker.client)
+				var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[xeno_attacker.ckey]
+				personal_statistics.miner_sabotages_performed++
 
 /obj/machinery/miner/proc/set_miner_status()
 	var/health_percent = round((miner_integrity / max_miner_integrity) * 100)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -682,6 +682,8 @@
 
 	var/mob/M = usr
 	var/chosen = tgui_input_list(usr, "Please, select an area.", "Select an area.", GLOB.sorted_areas, timeout = 0)
+	if(!chosen)
+		return // no tp's to the void
 	var/turf/T = pick(get_area_turfs(chosen))
 	M.forceMove(T)
 


### PR DESCRIPTION
## `Основные изменения`
Улучшения буров теперь также уничтожаются при поломке ксеносами.
Исправил то что Jump To Area телепортировал в нуллспейс при закрытии окошка с выбором.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Перманентные улучшения буров выглядят странно и не слишком балансно.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
add: Улучшения буров теперь также уничтожаются при поломке ксеносами.
fix: Исправил то что Jump To Area телепортировал в нуллспейс при закрытии окошка с выбором.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
