### PR TITLE
Weedifies Research Outpost and Orion Outpost.

### DIFF
--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -32,6 +32,10 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor,
 /area/barren/cave/lz1)
+"ap" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/barren/security)
 "aq" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 8
@@ -1007,6 +1011,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 4
 	},
@@ -3157,6 +3162,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar{
 	name = "medical"
 	},
@@ -3275,6 +3281,12 @@
 "pq" = (
 /turf/open/floor/plating,
 /area/barren/cave/lz2)
+"pr" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/barren/engie/two)
 "pu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3572,6 +3584,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/vault,
 /area/barren/civilian/laundry)
+"qM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar{
+	name = "medical"
+	},
+/area/barren/medical)
 "qN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3814,6 +3833,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
+"rO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/barren/security)
 "rQ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/lavaland/catwalk,
@@ -3843,6 +3866,7 @@
 /turf/open/floor/wood,
 /area/barren/civilian)
 "rY" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/vault{
 	dir = 5
 	},
@@ -3979,6 +4003,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/barren/cave/lz2)
+"sF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/lavaland/basalt,
+/area/barren/caves/south)
 "sG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/security,
@@ -4190,6 +4219,11 @@
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor,
 /area/barren/misc/genstorage)
+"tB" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/barren/medical/chemistry)
 "tD" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4381,6 +4415,13 @@
 /obj/structure/stairs,
 /turf/open/floor/mainship/black/full,
 /area/barren/security)
+"uy" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/barren/security)
 "uz" = (
 /obj/structure/window/reinforced/toughened{
 	dir = 8
@@ -4476,6 +4517,7 @@
 "uY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar{
 	name = "medical"
 	},
@@ -4832,6 +4874,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/barren/security)
 "wG" = (
@@ -4997,6 +5040,11 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden/layer2,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"xA" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/lavaland/basalt,
+/area/barren/caves/south)
 "xB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5913,6 +5961,7 @@
 /area/barren/caves/south)
 "BW" = (
 /obj/structure/bed/chair/wood/wings,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/barren/civilian/workdorm)
 "BX" = (
@@ -6437,6 +6486,10 @@
 	dir = 1
 	},
 /area/barren/medical)
+"EJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/barren/civilian/cook)
 "EM" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
@@ -6690,6 +6743,7 @@
 /area/barren)
 "FL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/barren/medical)
 "FN" = (
@@ -7986,6 +8040,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
 "Ma" = (
@@ -8007,6 +8062,13 @@
 	},
 /turf/open/floor/wood,
 /area/barren/civilian)
+"Mf" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar{
+	name = "medical"
+	},
+/area/barren/medical)
 "Mh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -8500,6 +8562,12 @@
 "OD" = (
 /turf/open/floor/plating/ground/lavaland/basalt,
 /area/barren/cave/northeast)
+"OG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar{
+	name = "medical"
+	},
+/area/barren/medical/chemistry)
 "OI" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
@@ -9295,6 +9363,13 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/lavaland/basalt,
 /area/barren/caves/southeast)
+"SB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean/two,
+/area/barren/security)
 "SD" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -9364,6 +9439,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/barren/security)
+"SS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar{
+	name = "medical"
+	},
+/area/barren/medical)
 "SV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -9682,6 +9763,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
 "Uu" = (
@@ -9733,6 +9815,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
+"UH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/barren/security)
 "UI" = (
 /obj/item/trash/candy,
 /turf/open/floor/wood,
@@ -10124,6 +10211,7 @@
 /area/barren/cave/lz1)
 "WJ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/bar{
 	name = "medical"
 	},
@@ -10792,6 +10880,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 1
 	},
@@ -13763,7 +13852,7 @@ PE
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -16054,7 +16143,7 @@ ZS
 Bi
 FZ
 tP
-tP
+SB
 Yd
 bm
 Bi
@@ -17330,7 +17419,7 @@ Ys
 Wh
 vF
 vF
-vF
+uy
 rN
 ys
 yk
@@ -17346,7 +17435,7 @@ ZS
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -17842,7 +17931,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 qn
 ZN
 ZN
@@ -17858,7 +17947,7 @@ Fy
 ik
 kf
 ZN
-ZN
+PE
 ZN
 Yb
 ZN
@@ -17967,7 +18056,7 @@ Bi
 lQ
 Hr
 lQ
-su
+rO
 su
 Hv
 te
@@ -18287,7 +18376,7 @@ Sx
 su
 ux
 eQ
-rD
+wr
 QQ
 Bi
 ZS
@@ -18445,7 +18534,7 @@ Sx
 su
 ux
 eQ
-wr
+rD
 re
 Bi
 ZS
@@ -18755,11 +18844,11 @@ fM
 ZS
 Bi
 mv
-su
+rO
 su
 su
 lQ
-Hv
+ap
 aW
 Zs
 re
@@ -19071,10 +19160,10 @@ fM
 ZS
 Bi
 dQ
-su
+rO
 Bi
 ly
-lQ
+UH
 Bi
 ZS
 tF
@@ -19095,7 +19184,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 AE
 ZS
@@ -19124,7 +19213,7 @@ ZS
 ZS
 ZN
 RD
-ZN
+PE
 ZN
 ZS
 ZS
@@ -19267,7 +19356,7 @@ ZS
 ZS
 ZS
 ZN
-ZN
+PE
 ZN
 ZS
 ZS
@@ -19308,7 +19397,7 @@ ZS
 ZS
 ZS
 YI
-YI
+QB
 YI
 YI
 YI
@@ -19418,7 +19507,7 @@ ZS
 ZS
 ZN
 ZN
-ZN
+PE
 ZN
 ZS
 ZS
@@ -19630,7 +19719,7 @@ YI
 YI
 YI
 Jv
-YI
+QB
 YI
 YI
 YI
@@ -19740,7 +19829,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -19780,7 +19869,7 @@ ZS
 ZS
 YI
 YI
-YI
+QB
 YI
 YI
 ZS
@@ -20380,7 +20469,7 @@ ZS
 Ko
 zr
 ZL
-ZL
+RH
 oo
 ZS
 ZN
@@ -20580,7 +20669,7 @@ OM
 Zg
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -21175,8 +21264,8 @@ ZL
 ZL
 ZL
 ZL
-ZL
 RH
+ZL
 ZL
 ZS
 ZS
@@ -22548,7 +22637,7 @@ Cn
 YQ
 YQ
 YQ
-YQ
+EJ
 YO
 zP
 ZS
@@ -24700,7 +24789,7 @@ ZS
 ZS
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -25497,7 +25586,7 @@ Zg
 Zg
 Zg
 Zg
-Zg
+Zb
 ZS
 Zg
 Zg
@@ -26841,7 +26930,7 @@ jH
 jH
 jH
 EH
-DU
+qM
 Qp
 Jl
 oh
@@ -26896,7 +26985,7 @@ ZS
 ZS
 Zg
 Zg
-WF
+xA
 Zg
 Zg
 Zg
@@ -27003,7 +27092,7 @@ eY
 Hb
 Jl
 YX
-PH
+tB
 qW
 OI
 Jl
@@ -27074,7 +27163,7 @@ Zg
 XB
 XB
 XB
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -27153,7 +27242,7 @@ ID
 lo
 jH
 vh
-DF
+SS
 RK
 jH
 CB
@@ -27307,7 +27396,7 @@ ZS
 ZS
 jH
 Ew
-DU
+qM
 ki
 jH
 sP
@@ -27637,7 +27726,7 @@ LD
 Is
 zf
 VM
-VM
+OG
 nF
 Jl
 ZS
@@ -27679,7 +27768,7 @@ ZS
 ZS
 ZS
 HN
-HN
+Bp
 HN
 Zg
 Zg
@@ -27785,7 +27874,7 @@ Fm
 jH
 jH
 zB
-AP
+Mf
 UF
 Fk
 Ds
@@ -27999,7 +28088,7 @@ CS
 DK
 ZS
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -28427,7 +28516,7 @@ MY
 ry
 DF
 DF
-DF
+SS
 mK
 dE
 wh
@@ -28569,7 +28658,7 @@ ZL
 ZL
 DF
 yA
-DU
+qM
 FP
 WC
 pB
@@ -28741,7 +28830,7 @@ fl
 jH
 jH
 Fv
-DF
+SS
 yW
 jH
 jH
@@ -28787,7 +28876,7 @@ Zg
 Zg
 ZS
 ZS
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -28798,7 +28887,7 @@ jy
 Zb
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 ZS
@@ -29100,7 +29189,7 @@ Zg
 WF
 Zg
 Zg
-Zg
+Zb
 Zg
 ZS
 Zg
@@ -29130,7 +29219,7 @@ Zg
 Lb
 Lb
 Lb
-Lb
+sF
 Lb
 Zg
 Zg
@@ -30525,7 +30614,7 @@ Zg
 Zg
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -30687,11 +30776,11 @@ Zg
 Zg
 Zg
 Zg
-Zg
+Zb
 ZS
 WF
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -33813,7 +33902,7 @@ Pv
 PL
 Qm
 Re
-Re
+pr
 Rn
 Oz
 wj
@@ -34009,7 +34098,7 @@ wj
 wj
 Lo
 wj
-wj
+Bz
 wj
 ZS
 WS

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -3,6 +3,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
+"ad" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostsw)
 "ae" = (
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/cargo)
@@ -29,6 +34,20 @@
 /obj/structure/prop/mainship/hangar_stencil,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/landing_pad_external)
+"ar" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/administration)
+"as" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outposts)
 "at" = (
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -67,6 +86,21 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/crashedufo)
+"aB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/monitor)
+"aC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/orion_outpost/surface/building/tadpolepad)
+"aD" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/surface/building/vehicledepot)
 "aE" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/terragov/north{
@@ -108,6 +142,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/underground/caveS)
+"aN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostcent)
 "aQ" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54"
@@ -161,6 +201,16 @@
 	dir = 1
 	},
 /area/orion_outpost/ground/outpostcent)
+"ba" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/brig)
 "bb" = (
 /obj/machinery/griddle,
 /turf/open/floor/mainship/mono,
@@ -225,6 +275,12 @@
 	dir = 1
 	},
 /area/orion_outpost/ground/outpostcent)
+"bp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/orion_outpost/surface/building/cargo)
 "bq" = (
 /obj/machinery/landinglight/lz1{
 	dir = 1
@@ -279,6 +335,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
+"bD" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/administration)
 "bE" = (
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/mainship/sterile/corner,
@@ -329,6 +390,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outposts)
+"bO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/orion_outpost/ground/outpostcent)
 "bP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
@@ -392,6 +460,10 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/building/atc)
+"cb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposts)
 "cc" = (
 /obj/structure/prop/mainship/mission_planning_system,
 /obj/structure/platform{
@@ -457,6 +529,11 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/engineering)
+"cu" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/orion_outpost/surface/building/medbay)
 "cw" = (
 /obj/structure/prop/brokenvendor/surplusarmor,
 /turf/open/floor/mainship/green,
@@ -479,6 +556,14 @@
 	dir = 4
 	},
 /area/orion_outpost/surface/building/prep)
+"cD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/orion_outpost/ground/outpostcent)
 "cF" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -494,6 +579,12 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/building/vehicledepot)
+"cK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 9
+	},
+/area/orion_outpost/surface/building/cargo)
 "cN" = (
 /obj/structure/prop/vehicle/crawler/crawler_red{
 	dir = 4
@@ -556,6 +647,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"db" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 6
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostcent)
 "dc" = (
 /obj/effect/turf_decal/riverdecal,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -732,6 +831,10 @@
 "dS" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostnw)
+"dU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue,
+/area/orion_outpost/surface/building/administration)
 "dV" = (
 /obj/structure/prop/brokenvendor/surplusarmor,
 /turf/open/floor/mainship/green{
@@ -750,6 +853,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outpostcent)
+"dY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/orion_outpost/surface/building/command)
 "dZ" = (
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/vehicledepot)
@@ -837,6 +946,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostcent)
+"ew" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/vehicledepot)
 "ex" = (
 /obj/structure/prop/vehicle/apc{
 	dir = 8
@@ -855,8 +970,16 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostcent)
+"ez" = (
+/obj/structure/flora/grass/tallgrass{
+	color = "#7a8c54"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposts)
 "eC" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 5
 	},
@@ -877,6 +1000,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/command)
 "eG" = (
@@ -891,6 +1015,7 @@
 	},
 /area/orion_outpost/surface/building/tadpolepad)
 "eI" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/terragov/north{
 	dir = 10
 	},
@@ -985,6 +1110,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/prep)
+"fd" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostsw)
 "ff" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -1008,6 +1141,10 @@
 /obj/machinery/landinglight/lz1,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/landing_pad_external)
+"fk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostcent)
 "fm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -1232,6 +1369,10 @@
 /obj/machinery/computer/autodoc_console,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
+"gp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/edge,
+/area/orion_outpost/ground/outpostnw)
 "gq" = (
 /obj/structure/cargo_container/hd,
 /turf/open/floor/mainship/mono,
@@ -1252,6 +1393,11 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/building/prep)
+"gz" = (
+/obj/machinery/door/airlock/prison/horizontal/open,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/brig)
 "gA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -1296,6 +1442,20 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outposte)
+"gJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/green{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/prep)
+"gL" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostse)
 "gM" = (
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outpostnw)
@@ -1424,6 +1584,16 @@
 /obj/structure/barricade/metal,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/surface/landing_pad2_external)
+"hB" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outpostsw)
+"hC" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outposte)
 "hE" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/mainship/orange{
@@ -1444,6 +1614,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/nebuilding)
+"hL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black,
+/area/orion_outpost/surface/building/atc)
 "hM" = (
 /obj/structure/prop/brokenvendor/brokenweaponsrack,
 /turf/open/floor/mainship/red,
@@ -1475,6 +1649,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/orion_outpost/surface/building/canteen)
 "hT" = (
@@ -1552,6 +1727,14 @@
 "in" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/orion_outpost/ground/outposts)
+"io" = (
+/obj/structure/cable,
+/obj/structure/desertdam/decals/road/line{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/surface/building/vehicledepot)
 "ip" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer3/server,
@@ -1582,6 +1765,11 @@
 	dir = 10
 	},
 /area/orion_outpost/surface/building/engineering)
+"iv" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue,
+/area/orion_outpost/surface/building/command)
 "iw" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/terragov/north{
@@ -1616,6 +1804,16 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/mainship/sterile/corner,
 /area/orion_outpost/surface/building/medbay)
+"iE" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/engineering)
+"iF" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/underground/caveE)
 "iI" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -1632,6 +1830,10 @@
 	dir = 4
 	},
 /area/orion_outpost/surface/building/vehicledepot)
+"iM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/dorms)
 "iN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1644,6 +1846,11 @@
 	dir = 8
 	},
 /area/orion_outpost/ground/outpostcent)
+"iP" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outpostsw)
 "iQ" = (
 /obj/effect/turf_decal/warning_stripes/medical,
 /obj/effect/turf_decal/warning_stripes/box/small,
@@ -1735,6 +1942,10 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
+"jl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostw)
 "jm" = (
 /obj/structure/prop/mainship/sensor_computer2,
 /obj/machinery/light{
@@ -1752,6 +1963,7 @@
 /area/orion_outpost/surface/building/cargo)
 "jq" = (
 /obj/structure/sink,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
 "js" = (
@@ -1788,12 +2000,30 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/breakroom)
+"jz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/orion_outpost/ground/outpostsw)
 "jA" = (
 /obj/structure/stairs/seamless/platform{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outposts)
+"jB" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/orion_outpost/ground/outposts)
+"jD" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 10
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostsw)
 "jE" = (
 /obj/structure/platform{
 	dir = 5
@@ -1858,6 +2088,10 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/building/command)
+"jR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/orion_outpost/ground/outposts)
 "jS" = (
 /obj/machinery/light{
 	dir = 4
@@ -1892,6 +2126,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/breakroom)
 "jY" = (
@@ -2016,6 +2251,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
+"kF" = (
+/obj/effect/turf_decal/riverdecal,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outposte)
 "kH" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/side{
@@ -2199,6 +2439,11 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostsw)
+"lz" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/canteen)
 "lA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -2237,6 +2482,11 @@
 "lJ" = (
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/breakroom)
+"lM" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposts)
 "lN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -2262,6 +2512,7 @@
 "lS" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/vehicledepot)
 "lT" = (
@@ -2371,6 +2622,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/grate/alternate,
 /area/orion_outpost/surface/building/engineering)
+"mw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/vehicledepot)
 "mx" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -2437,6 +2695,14 @@
 /obj/structure/prop/vehicle/truck/truckcargo,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
+"mO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/nebuilding)
 "mP" = (
 /turf/open/floor/mainship/green/corner,
 /area/orion_outpost/surface/building/prep)
@@ -2474,6 +2740,12 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
+"mY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/orion_outpost/ground/outpostse)
 "mZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2485,6 +2757,7 @@
 "na" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostsw)
 "nb" = (
@@ -2584,6 +2857,7 @@
 	color = "#7a8c54";
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostcent)
 "nt" = (
@@ -2648,6 +2922,10 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
+"nG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostse)
 "nJ" = (
 /obj/item/ammo_magazine/tank/ltb_cannon,
 /obj/item/ammo_magazine/tank/ltaap_chaingun,
@@ -2675,6 +2953,10 @@
 	dir = 10
 	},
 /area/orion_outpost/surface/building/cargo)
+"nQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostsw)
 "nR" = (
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -2778,6 +3060,14 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outposts)
+"ot" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostcent)
 "ov" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -2851,6 +3141,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/bunker)
+"oO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/surface/building/vehicledepot)
 "oP" = (
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostsw)
@@ -3172,6 +3466,19 @@
 "qi" = (
 /turf/closed/shuttle/dropship_regular/top_corner,
 /area/orion_outpost/surface/building/crashedufo)
+"qj" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/cargo)
+"qk" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 10
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposte)
 "ql" = (
 /obj/item/tool/wrench,
 /obj/effect/ai_node,
@@ -3226,13 +3533,6 @@
 /obj/structure/prop/brokenvendor/brokenuniformvendor/specialist,
 /turf/open/floor/mainship/green,
 /area/orion_outpost/surface/building/prep)
-"qz" = (
-/obj/structure/monorail{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/concrete,
-/area/orion_outpost/surface/building/cargo)
 "qA" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/desertdam/decals/road/line{
@@ -3498,6 +3798,7 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
 "rO" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/corner{
 	dir = 1
 	},
@@ -3538,6 +3839,11 @@
 "rX" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
+"rY" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/orion_outpost/surface/building/engineering)
 "rZ" = (
 /obj/machinery/status_display{
 	pixel_x = -15;
@@ -3604,6 +3910,12 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"sn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/orion_outpost/surface/building/armory)
 "so" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -3806,12 +4118,6 @@
 "te" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/orion_outpost/ground/outpostse)
-"tf" = (
-/obj/structure/barricade/metal{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/orion_outpost/surface/building/bunker)
 "tg" = (
 /turf/open/floor/mainship/red{
 	dir = 1
@@ -3878,6 +4184,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange/full,
 /area/orion_outpost/surface/building/cargo)
+"tA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/bunker)
 "tD" = (
 /obj/structure/flora/grass/tallgrass{
 	color = "#7a8c54"
@@ -3914,6 +4224,7 @@
 /area/orion_outpost/surface/building/medbay)
 "tL" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/breakroom)
 "tN" = (
@@ -3984,6 +4295,14 @@
 	dir = 4
 	},
 /area/orion_outpost/surface/building/medbay)
+"ug" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposte)
 "uh" = (
 /turf/open/floor/mainship/orange{
 	dir = 6
@@ -4011,6 +4330,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/nebuilding)
+"um" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostn)
 "un" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostsw)
@@ -4042,6 +4365,10 @@
 /obj/structure/nuke_disk_candidate,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/tadpolepad)
+"uC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostse)
 "uD" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -4100,6 +4427,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/atc)
+"uU" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/tadpolepad)
 "uW" = (
 /obj/machinery/vending/security,
 /turf/open/floor/mainship/red,
@@ -4162,6 +4494,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -4210,6 +4543,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/nebuilding)
+"vv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outposte)
 "vw" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/concrete/lines{
@@ -4219,6 +4556,7 @@
 "vx" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outposts)
 "vy" = (
@@ -4251,6 +4589,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/engineering)
+"vE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange/full,
+/area/orion_outpost/surface/building/cargo)
 "vG" = (
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/surface/building/breakroom)
@@ -4295,6 +4640,7 @@
 	},
 /area/orion_outpost/surface/building/medbay)
 "vS" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange,
 /area/orion_outpost/ground/outpostse)
 "vT" = (
@@ -4306,6 +4652,7 @@
 	color = "#7a8c54";
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostcent)
 "vW" = (
@@ -4403,11 +4750,20 @@
 "wt" = (
 /turf/closed/mineral/smooth,
 /area/orion_outpost/ground/outpostsw)
+"wu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg1,
+/area/orion_outpost/surface/building/crashedufo)
 "wv" = (
 /turf/open/floor/mainship/blue/corner{
 	dir = 8
 	},
 /area/orion_outpost/surface/building/administration)
+"wx" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange,
+/area/orion_outpost/surface/building/cargo)
 "wA" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -4435,6 +4791,7 @@
 /area/orion_outpost/surface/landing_pad_external)
 "wI" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
 	},
@@ -4515,6 +4872,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/surface/landing_pad2_external)
+"wZ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outpostse)
 "xa" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -4819,6 +5181,11 @@
 	dir = 9
 	},
 /area/orion_outpost/surface/building/administration)
+"yw" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outpostw)
 "yy" = (
 /obj/structure/prop/vehicle/truck,
 /turf/open/floor/plating/ground/concrete,
@@ -4887,6 +5254,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
 "yU" = (
@@ -4903,6 +5271,13 @@
 	dir = 9
 	},
 /area/orion_outpost/surface/building/engineering)
+"yW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostw)
 "yX" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
@@ -4965,6 +5340,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outpostcent)
 "zo" = (
@@ -5034,6 +5410,7 @@
 /area/orion_outpost/surface/landing_pad2_external)
 "zJ" = (
 /obj/item/ammo_casing/bullet,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/vehicledepot)
 "zK" = (
@@ -5141,6 +5518,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/underground/caveN/garbledradio)
+"Al" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/dorms)
+"Am" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/orion_outpost/ground/outpostw)
 "An" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -5296,6 +5685,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"Bd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/orion_outpost/ground/outpostsw)
 "Bf" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating/ground/concrete,
@@ -5329,6 +5722,10 @@
 	dir = 1
 	},
 /area/orion_outpost/ground/outpostw)
+"Bn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/surface/building/engineering)
 "Bo" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/smooth/indestructible,
@@ -5354,6 +5751,7 @@
 /area/orion_outpost/surface/building/cargo)
 "Bu" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
@@ -5365,6 +5763,12 @@
 "Bw" = (
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/vehicledepot)
+"Bx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 4
+	},
+/area/orion_outpost/ground/outpostnw)
 "By" = (
 /obj/effect/spawner/random/misc/structure/supplycrate/normalweighted,
 /obj/machinery/light{
@@ -5444,6 +5848,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/tadpolepad)
+"BT" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/engineering)
 "BU" = (
 /obj/structure/stairs/seamless/platform_vert{
 	dir = 8
@@ -5455,6 +5865,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/monitor)
+"BX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposte)
 "BY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -5577,6 +5992,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
 "Cz" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
 	},
@@ -5705,6 +6121,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/armory)
+"Db" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg1,
+/area/orion_outpost/ground/outpostse)
 "Dc" = (
 /obj/structure/prop/mainship/mission_planning_system,
 /turf/open/floor/mainship/mono,
@@ -5762,6 +6182,7 @@
 	},
 /area/orion_outpost/ground/outpostse)
 "Dq" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/black/corner{
 	dir = 8
 	},
@@ -5793,6 +6214,13 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostw)
+"DB" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/white,
+/area/orion_outpost/surface/building/dorms)
 "DD" = (
 /turf/open/floor/mainship/blue{
 	dir = 6
@@ -5824,6 +6252,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/prep)
+"DK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/green{
+	dir = 10
+	},
+/area/orion_outpost/surface/building/prep)
+"DL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/orion_outpost/surface/building/cargo)
 "DM" = (
 /turf/open/floor/mainship/sterile/white,
 /area/orion_outpost/ground/outposts)
@@ -5905,6 +6345,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/underground/caveE)
+"Ee" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/orion_outpost/surface/building/barracks)
 "Ef" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
@@ -5920,6 +6367,12 @@
 	dir = 8
 	},
 /area/orion_outpost/ground/outpostsw)
+"Eh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/red{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/brig)
 "Ei" = (
 /obj/effect/landmark/corpsespawner/marine,
 /obj/effect/decal/cleanable/blood,
@@ -5944,6 +6397,10 @@
 "Eo" = (
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/engineering)
+"Ep" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/vehicledepot)
 "Eq" = (
 /obj/machinery/light{
 	dir = 1
@@ -5984,6 +6441,10 @@
 	},
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/surface/building/prep)
+"EA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/brig,
+/area/orion_outpost/surface/building/crashedufo)
 "EB" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostcent)
@@ -6004,6 +6465,13 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"EG" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposts)
 "EH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -6039,6 +6507,16 @@
 	},
 /turf/open/floor/mainship/orange/full,
 /area/orion_outpost/surface/building/cargo)
+"EO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostcent)
 "EP" = (
 /obj/structure/barricade/plasteel{
 	dir = 8
@@ -6064,6 +6542,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostnw)
 "EV" = (
@@ -6075,6 +6554,21 @@
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
+"EX" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/white,
+/area/orion_outpost/surface/building/dorms)
+"EY" = (
+/obj/structure/bed/chair/office/dark,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/administration)
 "Fa" = (
 /turf/open/liquid/water/river,
 /area/orion_outpost/ground/river/riverside_central)
@@ -6126,6 +6620,13 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/administration)
+"Fs" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/orion_outpost/surface/building/tadpolepad)
 "Ft" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -6342,6 +6843,14 @@
 	dir = 9
 	},
 /area/orion_outpost/surface/building/prep)
+"GE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/cargo)
 "GF" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/concrete/edge,
@@ -6419,6 +6928,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 1
 	},
@@ -6429,6 +6939,14 @@
 	dir = 4
 	},
 /area/orion_outpost/surface/building/ammodepot)
+"Hb" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 10
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposts)
 "Hc" = (
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/administration)
@@ -6510,6 +7028,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
 	},
@@ -6557,6 +7076,12 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/landing_pad_2)
+"HH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/orion_outpost/surface/building/command)
 "HJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -6567,6 +7092,11 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/administration)
+"HO" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostcent)
 "HP" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
@@ -6700,6 +7230,10 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostcent)
+"Iv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/breakroom)
 "Iw" = (
 /obj/structure/platform{
 	dir = 1
@@ -6728,6 +7262,12 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/cargo)
+"ID" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/administration)
 "IH" = (
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
@@ -6737,6 +7277,15 @@
 /obj/item/stack/rods,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostse)
+"IK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outposts)
 "IL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/orange{
@@ -6765,6 +7314,18 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostse)
+"IU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/orion_outpost/surface/building/cargo)
+"IV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 6
+	},
+/area/orion_outpost/surface/building/cargo)
 "IX" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 9
@@ -6806,6 +7367,13 @@
 "Jd" = (
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/surface/building/barracks)
+"Je" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/orion_outpost/surface/building/tadpolepad)
 "Jf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -6867,6 +7435,13 @@
 /obj/effect/attach_point/electronics/dropship1,
 /turf/open/floor/plating,
 /area/orion_outpost/surface/landing_pad_2)
+"Jv" = (
+/obj/structure/desertdam/decals/road/line{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostnw)
 "Jw" = (
 /turf/open/floor/mainship/orange,
 /area/orion_outpost/surface/building/cargo)
@@ -6909,6 +7484,14 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/mainship/blue,
 /area/orion_outpost/surface/building/command)
+"JF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 8
+	},
+/area/orion_outpost/ground/outpostnw)
 "JG" = (
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/mainship/black{
@@ -7117,16 +7700,11 @@
 /area/orion_outpost/ground/outpostw)
 "KB" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange/corner{
 	dir = 1
 	},
 /area/orion_outpost/surface/building/cargo)
-"KC" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/orion_outpost/surface/building/bunker)
 "KE" = (
 /obj/effect/landmark/corpsespawner/marine/corpsman,
 /obj/effect/decal/cleanable/blood,
@@ -7137,6 +7715,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -7174,6 +7753,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/podhatch/floor,
 /area/orion_outpost/surface/building/crashedufo)
+"KQ" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/surface/building/prep)
 "KR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
@@ -7198,6 +7782,13 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/cargo)
+"KZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/nebuilding)
 "La" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
@@ -7382,6 +7973,10 @@
 /obj/structure/prop/vehicle/tank/east/armor,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/vehicledepot)
+"LN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/orion_outpost/surface/building/vehicledepot)
 "LP" = (
 /turf/open/floor/mainship/blue/corner{
 	dir = 8
@@ -7450,6 +8045,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/ground/outpostw)
+"Mj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outposte)
 "Ml" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 5
@@ -7499,6 +8098,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -7521,16 +8121,9 @@
 /area/orion_outpost/ground/outposts)
 "MD" = (
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
-"MF" = (
-/obj/structure/barricade/metal{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/orion_outpost/surface/building/bunker)
 "MG" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/freezer,
@@ -7593,7 +8186,12 @@
 /obj/structure/platform,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outposts)
+"MU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/atc)
 "MV" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 8
 	},
@@ -7629,6 +8227,7 @@
 /area/orion_outpost/surface/building/administration)
 "Nd" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
 "Ne" = (
@@ -7769,6 +8368,11 @@
 	dir = 1
 	},
 /area/orion_outpost/ground/outpostse)
+"NH" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/atc)
 "NI" = (
 /obj/structure/cargo_container/hd{
 	dir = 1
@@ -7796,6 +8400,14 @@
 /obj/structure/closet/secure_closet/freezer,
 /turf/open/floor/freezer,
 /area/orion_outpost/surface/building/canteen)
+"NR" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostnw)
 "NS" = (
 /turf/open/floor/wood,
 /area/orion_outpost/surface/building/dorms)
@@ -7856,6 +8468,7 @@
 /area/orion_outpost/surface/building/monitor)
 "Od" = (
 /obj/machinery/light,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/surface/building/vehicledepot)
 "Oe" = (
@@ -7871,6 +8484,10 @@
 	dir = 9
 	},
 /area/orion_outpost/surface/building/armory)
+"Oh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/side,
+/area/orion_outpost/surface/building/medbay)
 "Oi" = (
 /obj/structure/platform{
 	dir = 1
@@ -7919,6 +8536,12 @@
 "Or" = (
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/ground/outposts)
+"Os" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/orion_outpost/surface/building/medbay)
 "Ot" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/mainship/mono,
@@ -7926,8 +8549,13 @@
 "Ou" = (
 /obj/machinery/computer/body_scanconsole,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
+"Ox" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/ammodepot)
 "Oy" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -8046,6 +8674,10 @@
 	},
 /turf/open/liquid/water/river,
 /area/orion_outpost/ground/river/riverside_south)
+"Pa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/red,
+/area/orion_outpost/surface/building/monitor)
 "Pb" = (
 /turf/open/floor/mainship/orange{
 	dir = 1
@@ -8055,6 +8687,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
 "Pf" = (
@@ -8166,6 +8799,13 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/armory)
+"PF" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostsw)
 "PG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -8204,6 +8844,13 @@
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostse)
+"PP" = (
+/obj/structure/desertdam/decals/road{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/ground/outpostw)
 "PR" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/mono,
@@ -8248,6 +8895,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/orion_outpost/ground/outpostsw)
 "Qe" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -8288,6 +8936,12 @@
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/monitor)
+"Qo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostnw)
 "Qp" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outposts)
@@ -8297,11 +8951,19 @@
 	dir = 8
 	},
 /area/orion_outpost/ground/outpostsw)
+"Qr" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/cargo)
 "Qs" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostn)
 "Qt" = (
@@ -8387,6 +9049,12 @@
 "QU" = (
 /turf/closed/mineral/smooth/indestructible,
 /area/orion_outpost/ground/outposts)
+"QW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/cargo)
 "QX" = (
 /obj/machinery/bodyscanner{
 	dir = 8
@@ -8423,6 +9091,14 @@
 	dir = 9
 	},
 /area/orion_outpost/surface/building/armory)
+"Rf" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostcent)
 "Rg" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
@@ -8610,6 +9286,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/breakroom)
+"Sd" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/orion_outpost/surface/building/prep)
 "Se" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -8833,6 +9516,11 @@
 /obj/structure/table/mainship,
 /turf/open/floor/wood,
 /area/orion_outpost/surface/building/administration)
+"Tf" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/orion_outpost/ground/outposts)
 "Th" = (
 /obj/effect/landmark/corpsespawner/marine/engineer,
 /turf/open/floor/mainship/mono,
@@ -8951,8 +9639,14 @@
 /area/orion_outpost/surface/building/administration)
 "TK" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/orion_outpost/ground/outposte)
+"TL" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/command)
 "TM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
@@ -8997,6 +9691,14 @@
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
 /area/orion_outpost/surface/landing_pad)
+"TX" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostnw)
 "TZ" = (
 /obj/structure/table/mainship,
 /obj/machinery/microwave,
@@ -9129,10 +9831,6 @@
 	dir = 1
 	},
 /area/orion_outpost/surface/building/command)
-"UI" = (
-/obj/structure/barricade/metal,
-/turf/open/floor/mainship/mono,
-/area/orion_outpost/surface/building/bunker)
 "UK" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/noglass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9161,10 +9859,8 @@
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/orion_outpost/surface/landing_pad_external)
 "US" = (
-/obj/structure/barricade/metal{
-	dir = 4
-	},
 /obj/effect/spawner/random/weaponry/gun/rifles,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/bunker)
 "UT" = (
@@ -9177,6 +9873,15 @@
 "UU" = (
 /turf/closed/mineral/smooth,
 /area/orion_outpost/ground/outpostse)
+"UY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostsw)
 "UZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/terragov/north,
@@ -9419,6 +10124,14 @@
 	},
 /turf/closed/wall/mainship/gray,
 /area/orion_outpost/surface/building/barracks)
+"Wf" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 5
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostw)
 "Wg" = (
 /obj/structure/rack,
 /turf/open/floor/mainship/orange{
@@ -9532,6 +10245,11 @@
 /obj/effect/spawner/random/weaponry/gun/rifles,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/vehicledepot)
+"WG" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/orion_outpost/ground/outpostcent)
 "WH" = (
 /obj/effect/attach_point/weapon/dropship1,
 /turf/open/floor/plating,
@@ -9544,6 +10262,11 @@
 /obj/structure/stairs/seamless,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostcent)
+"WK" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/orion_outpost/surface/building/barracks)
 "WL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -9578,6 +10301,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/cargo)
+"WV" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostcent)
+"WW" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/ammodepot)
 "WY" = (
 /obj/structure/rack,
 /obj/structure/platform,
@@ -9807,6 +10540,7 @@
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostsw)
 "Yf" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
 	},
@@ -9857,6 +10591,13 @@
 	dir = 8
 	},
 /area/orion_outpost/surface/building/engineering)
+"Yr" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostcent)
 "Ys" = (
 /obj/machinery/shower,
 /obj/structure/curtain/shower,
@@ -9892,6 +10633,7 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
 "Yy" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/orange{
 	dir = 6
 	},
@@ -9967,6 +10709,7 @@
 	color = "#7a8c54";
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostw)
 "YU" = (
@@ -9979,6 +10722,16 @@
 "YX" = (
 /turf/closed/mineral/smooth/indestructible,
 /area/orion_outpost/ground/outpostsw)
+"YY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
+/area/orion_outpost/surface/building/command)
+"YZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/surface/building/cargo)
 "Za" = (
 /obj/structure/desertdam/decals/road/edge/long{
 	dir = 1
@@ -10068,6 +10821,18 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/dorms)
+"Zt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostsw)
+"Zu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines{
+	dir = 1
+	},
+/area/orion_outpost/ground/outpostw)
 "Zv" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/blue{
@@ -10116,6 +10881,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/orion_outpost/ground/outpostcent)
 "ZE" = (
@@ -10131,6 +10897,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/armory)
+"ZJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/concrete/lines,
+/area/orion_outpost/ground/outpostw)
 "ZK" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray,
@@ -10143,6 +10913,14 @@
 	dir = 4
 	},
 /area/orion_outpost/ground/outpostse)
+"ZP" = (
+/obj/structure/flora/grass/tallgrass/tallgrasscorner{
+	color = "#7a8c54";
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/orion_outpost/ground/outpostsw)
 "ZQ" = (
 /obj/structure/flora/grass/tallgrass/tallgrasscorner{
 	color = "#7a8c54";
@@ -10178,7 +10956,6 @@
 "ZW" = (
 /obj/effect/landmark/corpsespawner/marine,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/concrete,
 /area/orion_outpost/ground/outpostse)
 "ZX" = (
@@ -10377,7 +11154,7 @@ Mf
 YQ
 YQ
 YQ
-YQ
+Dx
 YQ
 YQ
 YQ
@@ -10498,7 +11275,7 @@ lW
 lW
 lW
 Un
-lW
+xa
 lW
 YQ
 YQ
@@ -10638,21 +11415,21 @@ YQ
 YQ
 YQ
 YQ
-YQ
-YQ
 Dx
 YQ
 YQ
 YQ
 YQ
 YQ
+YQ
+YQ
 Mh
 YQ
 Mh
 YQ
 YQ
 YQ
-YQ
+Dx
 YQ
 YQ
 Mh
@@ -10692,7 +11469,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 ve
@@ -10764,9 +11541,9 @@ lW
 Un
 lW
 lW
+Dx
 YQ
-YQ
-YQ
+Dx
 YQ
 YQ
 YQ
@@ -10774,10 +11551,10 @@ Mh
 RA
 YQ
 YQ
+Dx
 YQ
 YQ
-YQ
-Mh
+yw
 Mf
 Mf
 Mf
@@ -10815,12 +11592,12 @@ ve
 ve
 ve
 ve
-ve
+JW
 ly
 un
 un
 Kx
-un
+nQ
 ve
 ve
 ve
@@ -10831,12 +11608,12 @@ ve
 ve
 ve
 ve
+JW
 ve
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 ve
 wt
@@ -10885,7 +11662,7 @@ zI
 zI
 dl
 Df
-lW
+xa
 Un
 lW
 lW
@@ -10958,7 +11735,7 @@ xp
 mV
 ve
 ve
-bA
+hB
 ve
 ve
 ve
@@ -11026,17 +11803,17 @@ lW
 lW
 lW
 Un
+xa
 lW
-lW
 Mf
 Mf
 Mf
 Mf
-mn
+Wf
 JC
 JC
 YQ
-YQ
+Dx
 Mf
 Mf
 Mf
@@ -11055,7 +11832,7 @@ YQ
 YQ
 YQ
 ve
-ve
+JW
 ve
 wt
 wt
@@ -11066,7 +11843,7 @@ wt
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -11087,16 +11864,16 @@ uQ
 uQ
 uQ
 Sx
+JW
 ve
 ve
 ve
 ve
+JW
 ve
 ve
 ve
-ve
-ve
-ve
+JW
 ve
 ve
 ve
@@ -11234,11 +12011,11 @@ ve
 ve
 ve
 un
+nQ
 un
-un
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -11299,8 +12076,8 @@ Mf
 Mf
 Hh
 kO
-JC
-YQ
+jl
+Dx
 YQ
 YQ
 Mf
@@ -11343,7 +12120,7 @@ wt
 ve
 ve
 ve
-ve
+JW
 wt
 wt
 wt
@@ -11363,7 +12140,7 @@ wt
 wt
 wt
 wt
-ve
+JW
 mV
 un
 Kx
@@ -11418,8 +12195,8 @@ ap
 ap
 ng
 ng
-KC
-KC
+Rj
+Rj
 ng
 ng
 ng
@@ -11437,7 +12214,7 @@ JC
 RA
 YQ
 YQ
-YQ
+Dx
 YQ
 YQ
 YQ
@@ -11450,7 +12227,7 @@ kO
 tT
 YQ
 YQ
-mV
+iP
 un
 ve
 ve
@@ -11485,9 +12262,9 @@ wt
 wt
 ve
 ve
+JW
 ve
-ve
-ve
+JW
 ve
 ve
 wt
@@ -11498,7 +12275,7 @@ wt
 ve
 un
 nm
-iV
+fd
 Sx
 un
 un
@@ -11556,7 +12333,7 @@ Rj
 Rj
 Rj
 Ir
-MM
+Am
 Cf
 MM
 MM
@@ -11573,7 +12350,7 @@ MM
 MM
 MM
 MM
-MM
+Am
 MM
 MM
 MM
@@ -11595,14 +12372,14 @@ ve
 ve
 ve
 ve
+JW
+ve
+ve
+JW
 ve
 ve
 ve
-ve
-ve
-ve
-ve
-ve
+JW
 ve
 ve
 JW
@@ -11633,7 +12410,7 @@ uQ
 Dl
 ZB
 un
-un
+nQ
 ve
 ve
 ve
@@ -11684,13 +12461,17 @@ ng
 js
 Rj
 AK
-Rj
+tA
 AK
 ng
 oB
 Ub
 Ub
 Ub
+LG
+Ub
+Ub
+LG
 Ub
 Ub
 Ub
@@ -11707,18 +12488,14 @@ Ub
 Ub
 Ub
 Ub
-Ub
-Ub
-Ub
-Ub
-Ub
+LG
 Ub
 Ba
 Kx
 un
 un
 mV
-ve
+JW
 ve
 ve
 ve
@@ -11814,11 +12591,11 @@ ap
 lW
 ng
 es
-Rj
+tA
 Rj
 eg
 ni
-UI
+Rj
 oB
 Ub
 GF
@@ -11834,7 +12611,7 @@ lb
 lb
 lb
 lb
-lb
+cG
 rG
 lb
 lb
@@ -11873,19 +12650,19 @@ ve
 bA
 ve
 ve
+JW
 ve
 ve
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 bA
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -11900,7 +12677,7 @@ nm
 Sx
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -11950,7 +12727,7 @@ QN
 JT
 Rj
 Rj
-UI
+tA
 oB
 Ub
 FI
@@ -11985,14 +12762,14 @@ ve
 ve
 bA
 ve
+JW
 ve
 ve
-ve
-ve
+JW
 ve
 un
 nm
-iV
+fd
 Sx
 un
 Kx
@@ -12008,7 +12785,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 ve
@@ -12030,7 +12807,7 @@ Kx
 un
 YK
 ZB
-mV
+iP
 ve
 ve
 ve
@@ -12074,11 +12851,11 @@ eW
 hz
 Df
 lW
-lW
+xa
 lW
 ng
 ng
-tf
+Rj
 US
 ng
 ng
@@ -12132,34 +12909,34 @@ ve
 ve
 ve
 ve
+JW
+ve
+wt
+wt
+wt
+wt
+ve
+ve
+ve
+ve
+ve
+ve
+ve
+ve
+ve
+ve
+ve
 ve
 ve
 wt
 wt
 wt
 wt
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
-ve
 wt
 wt
 wt
 wt
-wt
-wt
-wt
-wt
-mV
+iP
 ve
 ve
 ve
@@ -12167,7 +12944,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 wt
 YX
 "}
@@ -12225,21 +13002,21 @@ cm
 zY
 oA
 gY
-Hc
+HV
 RG
 Hc
 wv
-Qh
+sA
 Qh
 Qh
 sA
 Fr
 gY
-Hc
+HV
 Hc
 OM
 pN
-qm
+Zu
 Ub
 Ba
 Kx
@@ -12275,11 +13052,11 @@ ve
 ve
 ve
 ve
+JW
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 ve
 ve
@@ -12352,7 +13129,7 @@ Ub
 FI
 DX
 WS
-Hc
+HV
 pN
 pN
 Dn
@@ -12429,7 +13206,7 @@ wt
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -12474,13 +13251,13 @@ mh
 mh
 mh
 mh
+Zg
 mh
 mh
-mh
-mh
+Zg
 mh
 SK
-Ub
+LG
 wb
 pN
 Wu
@@ -12603,7 +13380,7 @@ sw
 tJ
 nd
 nd
-nd
+Bx
 nd
 nd
 nd
@@ -12645,7 +13422,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 wt
 wt
 wt
@@ -12771,7 +13548,7 @@ qm
 Ub
 Ba
 ve
-ve
+JW
 ve
 ve
 ve
@@ -12870,7 +13647,7 @@ lW
 lW
 lW
 lW
-lW
+xa
 lW
 lW
 lW
@@ -12900,7 +13677,7 @@ ke
 Ik
 pN
 qm
-Ub
+LG
 Ba
 ve
 ve
@@ -12957,7 +13734,7 @@ wt
 wt
 ve
 ve
-ve
+JW
 ve
 wt
 wt
@@ -13006,11 +13783,11 @@ lW
 lW
 lW
 lW
-lW
+xa
 oB
 Ub
 Ko
-Ub
+LG
 Ub
 Ub
 LG
@@ -13036,9 +13813,9 @@ Ub
 Ba
 ng
 ng
-KC
+Rj
 ng
-ve
+JW
 ve
 ve
 ve
@@ -13131,7 +13908,7 @@ WO
 rp
 ap
 lW
-lW
+xa
 lW
 lW
 lW
@@ -13152,7 +13929,7 @@ hv
 Qy
 Wz
 vl
-Hc
+HV
 VU
 Hc
 mt
@@ -13169,12 +13946,12 @@ Ba
 ng
 Rj
 Rj
-UI
+Rj
 ve
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -13286,21 +14063,21 @@ Hc
 qo
 vl
 Hc
-Hc
+HV
 Hc
 HL
 yr
-Hc
+HV
 rJ
 eO
-OM
+dU
 DX
 qm
 Ub
 NV
 Rj
 JT
-Rj
+tA
 ng
 ve
 ve
@@ -13354,7 +14131,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 wt
 wt
 YX
@@ -13433,15 +14210,15 @@ Ba
 ng
 Rj
 Rj
-UI
+Rj
+ve
+JW
 ve
 ve
 ve
 ve
 ve
-ve
-ve
-ve
+JW
 ve
 xg
 hq
@@ -13476,14 +14253,14 @@ UR
 aX
 xg
 ve
-ve
+JW
 wt
 wt
 wt
 wt
 ve
 ve
-ve
+JW
 ve
 ve
 ve
@@ -13537,11 +14314,11 @@ Ib
 Kq
 Mg
 Ub
-Ub
+LG
 Ub
 Ww
 Ub
-oZ
+yW
 FI
 pN
 pN
@@ -13564,7 +14341,7 @@ LG
 NV
 ng
 ng
-tf
+Rj
 ng
 ve
 ve
@@ -13680,7 +14457,7 @@ ow
 Ub
 DX
 mo
-Hc
+HV
 Hc
 fh
 pN
@@ -13744,14 +14521,14 @@ ve
 ve
 ve
 ve
+JW
 ve
 ve
 ve
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 YX
 "}
@@ -13808,7 +14585,7 @@ Ub
 oZ
 Ub
 kX
-FI
+ZJ
 Ub
 DX
 mo
@@ -13816,7 +14593,7 @@ Hc
 Hc
 sE
 yr
-Zv
+ar
 tm
 sG
 vX
@@ -13828,7 +14605,7 @@ Yh
 uN
 Jx
 Jx
-Jx
+ad
 Jx
 Jx
 Jx
@@ -13872,14 +14649,14 @@ UR
 EL
 xg
 ve
+JW
 ve
 ve
 ve
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 bA
 ve
@@ -13929,7 +14706,7 @@ Oj
 RB
 eT
 wr
-lt
+hL
 Kq
 ta
 Ms
@@ -14082,17 +14859,17 @@ pN
 pN
 Zv
 Hc
-Hc
+HV
 rJ
 eO
-OM
+dU
 Hc
 vw
-Ub
+LG
 Ba
 ng
 ng
-KC
+Rj
 ng
 ve
 ve
@@ -14139,14 +14916,14 @@ ve
 ve
 ve
 ve
-mV
+iP
 ve
 ve
 ve
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 YX
@@ -14192,7 +14969,7 @@ ii
 eM
 lE
 NJ
-so
+NH
 lt
 Kq
 Mg
@@ -14202,9 +14979,9 @@ Ub
 Ww
 Ub
 oZ
+LG
 Ub
-Ub
-FI
+ZJ
 uM
 pN
 JN
@@ -14225,7 +15002,7 @@ Ba
 ng
 Rj
 Rj
-UI
+Rj
 mV
 ve
 ve
@@ -14317,7 +15094,7 @@ rp
 Kq
 lx
 wr
-wr
+MU
 Em
 Kq
 AD
@@ -14329,7 +15106,7 @@ lt
 Kq
 KA
 OA
-Lv
+PP
 Lv
 cq
 Ub
@@ -14356,11 +15133,11 @@ Ub
 NV
 Rj
 JT
-Rj
+tA
 ng
 un
 ve
-ve
+JW
 ve
 wt
 wt
@@ -14454,7 +15231,7 @@ Em
 Kq
 eQ
 wr
-lt
+hL
 Kq
 Eq
 lt
@@ -14473,14 +15250,14 @@ Fj
 Hc
 mo
 Hc
-zC
+bD
 Hc
 Hc
 Sv
+Nc
 ui
 ui
-ui
-ui
+Nc
 DD
 DX
 ZR
@@ -14489,7 +15266,7 @@ Ba
 ng
 Rj
 Rj
-UI
+Rj
 un
 ve
 ve
@@ -14536,13 +15313,13 @@ wt
 wt
 wt
 uQ
-qw
+ZP
 un
 un
+JW
 ve
 ve
-ve
-ve
+JW
 wt
 wt
 YX
@@ -14582,19 +15359,19 @@ Kq
 xj
 so
 wr
-wr
+MU
 NJ
 wr
 so
 lt
 Kq
 lx
-wr
+MU
 fn
 Mg
 Ub
 Ub
-Ub
+LG
 Ww
 Ub
 oZ
@@ -14616,11 +15393,11 @@ Hc
 QJ
 pN
 ZR
-Ub
+LG
 Ba
 ng
 ng
-tf
+Rj
 ng
 zq
 ve
@@ -14688,7 +15465,7 @@ ap
 lW
 lW
 lW
-lW
+xa
 lW
 lW
 lW
@@ -14708,7 +15485,7 @@ lW
 pX
 mh
 mh
-lW
+xa
 lW
 Kq
 iB
@@ -14732,7 +15509,7 @@ PJ
 oZ
 Ub
 Ub
-FI
+ZJ
 Ub
 pN
 aF
@@ -14744,7 +15521,7 @@ pN
 Id
 Js
 Lm
-Hc
+HV
 vl
 pN
 ZR
@@ -14759,7 +15536,7 @@ un
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 wt
@@ -14806,7 +15583,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 wt
 wt
 YX
@@ -14816,13 +15593,13 @@ WQ
 ap
 ap
 ap
+xa
 lW
 lW
 lW
 lW
 lW
-lW
-lW
+xa
 lW
 ap
 ap
@@ -14857,7 +15634,7 @@ Uz
 Kq
 KA
 Lv
-Lv
+PP
 Lv
 Lv
 wI
@@ -14870,7 +15647,7 @@ pN
 BK
 Qy
 OE
-xu
+EY
 CM
 pN
 HL
@@ -14883,11 +15660,11 @@ ZR
 Ub
 Ba
 un
-YK
+jD
 Dl
 uQ
 Sx
-un
+nQ
 ve
 ve
 ve
@@ -14977,7 +15754,7 @@ va
 va
 va
 va
-va
+JF
 Bq
 va
 va
@@ -14985,7 +15762,7 @@ va
 va
 va
 va
-iO
+cD
 iO
 iO
 sj
@@ -15005,7 +15782,7 @@ zC
 vt
 jb
 pN
-mo
+ID
 pN
 pN
 Hc
@@ -15063,7 +15840,7 @@ wt
 wt
 wt
 ve
-ve
+JW
 ve
 Ci
 Ci
@@ -15123,13 +15900,13 @@ WJ
 pj
 pj
 DQ
-pj
+jw
 St
 pj
 yT
 pj
 AO
-pj
+jw
 pN
 Pw
 Hc
@@ -15143,13 +15920,13 @@ eO
 HV
 OM
 pN
-Vo
+Yr
 pj
 gP
 un
 un
 un
-un
+nQ
 un
 ve
 TU
@@ -15202,7 +15979,7 @@ wt
 ve
 ve
 ve
-ve
+JW
 ly
 wt
 YX
@@ -15216,7 +15993,7 @@ ap
 lW
 lW
 lW
-lW
+xa
 dS
 ap
 ap
@@ -15248,7 +16025,7 @@ nd
 xv
 mh
 mh
-Vi
+gp
 oR
 oR
 oR
@@ -15278,7 +16055,7 @@ pN
 Vo
 pj
 zZ
-un
+nQ
 Kx
 wt
 wt
@@ -15286,7 +16063,7 @@ wt
 Sk
 TU
 Og
-nX
+sn
 gm
 TU
 wt
@@ -15360,17 +16137,17 @@ MH
 lW
 lW
 lW
-jJ
+Qo
 nF
 nF
 nF
 mX
+Jv
 nF
 nF
 nF
 nF
-nF
-nF
+Jv
 nF
 gM
 lW
@@ -15478,7 +16255,7 @@ ap
 ap
 ap
 lW
-lW
+xa
 lW
 lW
 Sj
@@ -15487,7 +16264,7 @@ dm
 ap
 ap
 wq
-Ef
+TX
 rE
 lW
 lW
@@ -15517,13 +16294,13 @@ nb
 CA
 Gy
 OP
-On
+aD
 dZ
 lB
 dZ
 li
 bf
-pj
+jw
 AO
 pj
 pN
@@ -15541,9 +16318,9 @@ pN
 pN
 Vo
 pj
-zZ
+bO
 ve
-mV
+iP
 wt
 wt
 wt
@@ -15590,7 +16367,7 @@ wt
 wt
 wt
 ve
-ve
+JW
 ve
 wt
 Ci
@@ -15615,7 +16392,7 @@ lW
 lW
 dS
 Sj
-wq
+NR
 Ef
 dS
 WL
@@ -15643,7 +16420,7 @@ li
 Zp
 NX
 dZ
-dZ
+oO
 lB
 VN
 bd
@@ -15663,11 +16440,11 @@ rt
 rt
 rt
 rt
+ev
 rt
 rt
 rt
-rt
-rt
+ev
 rt
 rt
 rt
@@ -15764,7 +16541,7 @@ IZ
 nd
 Hs
 nd
-nd
+Bx
 Zh
 VL
 VL
@@ -15772,7 +16549,7 @@ jS
 rt
 rt
 li
-dZ
+oO
 OP
 dZ
 ex
@@ -15789,10 +16566,10 @@ li
 bf
 pj
 AO
+ev
 rt
 rt
-rt
-rt
+ev
 rt
 rt
 rt
@@ -15839,9 +16616,9 @@ ve
 ve
 ve
 ve
-ve
+JW
 Lp
-Jx
+ad
 su
 ve
 ve
@@ -15856,7 +16633,7 @@ wt
 wt
 ve
 ve
-ve
+JW
 ly
 ly
 Ci
@@ -15883,14 +16660,14 @@ WL
 CF
 dS
 dS
+xa
 lW
-lW
 pW
 pW
 pW
 ae
 ae
-ae
+YZ
 ae
 XI
 pW
@@ -15901,7 +16678,7 @@ pW
 ae
 lQ
 pW
-rt
+ev
 rt
 Ut
 dZ
@@ -15915,7 +16692,7 @@ WY
 OP
 dZ
 dZ
-lB
+LN
 dZ
 Ut
 bf
@@ -15926,13 +16703,13 @@ rt
 rt
 rt
 rt
+ev
 rt
 rt
+ev
 rt
 rt
-rt
-rt
-rt
+ev
 rt
 jY
 Vo
@@ -15965,10 +16742,10 @@ wt
 wt
 ve
 ve
+JW
 ve
 ve
-ve
-ve
+JW
 ve
 ve
 ve
@@ -15977,7 +16754,7 @@ Jx
 su
 ve
 ve
-ve
+JW
 ve
 wt
 wt
@@ -16025,12 +16802,12 @@ AW
 LK
 AW
 yE
-Ia
+IU
 nP
 pW
 Qw
 SC
-Qw
+qE
 Qw
 pW
 rt
@@ -16042,7 +16819,7 @@ dZ
 dZ
 lB
 yP
-Bw
+Ep
 ku
 OP
 dZ
@@ -16089,13 +16866,13 @@ eu
 ZL
 tH
 ve
+JW
 ve
 ve
 ve
 ve
 ve
-ve
-ve
+JW
 ve
 ve
 ve
@@ -16144,7 +16921,7 @@ lW
 lW
 lW
 lW
-lW
+xa
 lW
 lW
 lW
@@ -16172,7 +16949,7 @@ RE
 OP
 dZ
 dZ
-lB
+LN
 Oi
 Bw
 tW
@@ -16183,7 +16960,7 @@ lB
 RE
 Ro
 bf
-hu
+HO
 AO
 dF
 vG
@@ -16203,7 +16980,7 @@ Vo
 pj
 zZ
 rt
-rt
+ev
 ve
 wt
 wt
@@ -16223,7 +17000,7 @@ tH
 mC
 XN
 XN
-XN
+Qq
 XN
 XN
 XN
@@ -16240,7 +17017,7 @@ Lp
 Jx
 su
 ve
-Jb
+KQ
 QB
 QB
 Uq
@@ -16269,17 +17046,17 @@ ap
 ap
 ap
 lW
+xa
+lW
+lW
+xa
 lW
 lW
 lW
 lW
 lW
 lW
-lW
-lW
-lW
-lW
-lW
+xa
 pW
 IL
 Qb
@@ -16292,7 +17069,7 @@ lr
 Qw
 Qw
 FC
-Qw
+qE
 qr
 pi
 pi
@@ -16300,7 +17077,7 @@ Nw
 dF
 rt
 li
-dZ
+oO
 pP
 Nr
 Nr
@@ -16312,7 +17089,7 @@ XX
 Nr
 Nr
 Iz
-dZ
+oO
 li
 bf
 St
@@ -16327,9 +17104,9 @@ jy
 vG
 rt
 rt
-jY
+WG
 sD
-jI
+db
 tV
 Vo
 rU
@@ -16361,7 +17138,7 @@ yy
 oP
 oP
 su
-ve
+JW
 ve
 wt
 wt
@@ -16369,7 +17146,7 @@ wt
 wt
 wt
 Lp
-Jx
+ad
 su
 ve
 yp
@@ -16381,7 +17158,7 @@ sS
 sS
 kK
 lD
-Mw
+DK
 LR
 DU
 DU
@@ -16389,7 +17166,7 @@ Qp
 Qp
 Qp
 kY
-Co
+EG
 lq
 lq
 lq
@@ -16413,16 +17190,16 @@ lW
 ap
 ap
 pW
-IL
+Qr
 Rv
 Qw
-Qw
+qE
 gk
 LA
 Qw
 lr
 Qw
-Qw
+qE
 ae
 fZ
 Md
@@ -16430,7 +17207,7 @@ Md
 kR
 Nw
 rt
-rt
+ev
 li
 YE
 YE
@@ -16441,7 +17218,7 @@ VN
 Bw
 Cj
 dZ
-dZ
+oO
 RE
 wp
 YE
@@ -16453,9 +17230,9 @@ rt
 vG
 Xf
 zF
-lJ
+Iv
 fp
-lJ
+Iv
 Yw
 rt
 rt
@@ -16466,7 +17243,7 @@ bG
 Vo
 pj
 zZ
-rt
+ev
 EB
 EB
 EB
@@ -16474,7 +17251,7 @@ un
 ve
 ve
 mV
-ve
+JW
 ve
 TU
 tH
@@ -16509,14 +17286,14 @@ fc
 iX
 iX
 xX
-xX
+Sd
 dg
 kK
 wa
 og
 LR
 DU
-DU
+GI
 kY
 Du
 lq
@@ -16539,7 +17316,7 @@ lW
 lW
 lW
 lW
-lW
+xa
 ap
 ap
 ap
@@ -16557,7 +17334,7 @@ Qw
 jG
 pW
 Qw
-Qw
+qE
 cz
 Qw
 pW
@@ -16570,7 +17347,7 @@ dZ
 dZ
 dZ
 lw
-mG
+mw
 Ap
 dZ
 dZ
@@ -16581,7 +17358,7 @@ li
 bf
 pj
 AO
-rt
+ev
 Yw
 lJ
 Jn
@@ -16602,7 +17379,7 @@ EB
 sD
 tr
 EB
-sD
+WV
 EB
 un
 Qc
@@ -16616,7 +17393,7 @@ Hg
 Dr
 vJ
 Qc
-Lp
+Zt
 oP
 xt
 oP
@@ -16650,7 +17427,7 @@ MA
 DU
 DU
 Qp
-Co
+EG
 lq
 lq
 lq
@@ -16710,7 +17487,7 @@ Ut
 li
 li
 li
-bf
+EO
 pj
 AO
 rt
@@ -16724,7 +17501,7 @@ vG
 rt
 rt
 rt
-rt
+ev
 jY
 EB
 Vo
@@ -16753,7 +17530,7 @@ fT
 VJ
 Jx
 Jx
-Jx
+ad
 Jx
 Jx
 Jx
@@ -16853,14 +17630,14 @@ Tc
 Tc
 Tc
 rt
-rt
+ev
 rt
 rt
 rt
 rt
 rt
 Vo
-pj
+jw
 zZ
 uS
 Nv
@@ -16870,10 +17647,10 @@ Pn
 Pn
 fM
 fM
+jz
 fM
 fM
-fM
-fM
+jz
 Gz
 fM
 fM
@@ -16899,7 +17676,7 @@ Mq
 AP
 oP
 Sn
-ve
+JW
 ve
 oU
 tY
@@ -16912,7 +17689,7 @@ kK
 GG
 QB
 DU
-DU
+GI
 DU
 qJ
 lq
@@ -16946,7 +17723,7 @@ Qb
 Qw
 qX
 qX
-jo
+vE
 Qw
 Qw
 Cm
@@ -16961,7 +17738,7 @@ dF
 rt
 Ro
 OP
-dZ
+oO
 dZ
 zy
 rH
@@ -17008,7 +17785,7 @@ Fn
 SZ
 me
 Fn
-Qc
+Bd
 aJ
 XU
 XU
@@ -17026,7 +17803,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 ve
 yc
 Tt
@@ -17102,7 +17879,7 @@ Oe
 XL
 TP
 Vg
-sk
+io
 sk
 Ta
 nx
@@ -17155,7 +17932,7 @@ ve
 ve
 ve
 ve
-ve
+JW
 ve
 ve
 ve
@@ -17164,7 +17941,7 @@ yc
 oP
 Sn
 ve
-ve
+JW
 LR
 vh
 kK
@@ -17196,7 +17973,7 @@ ap
 ap
 lW
 lW
-lW
+xa
 lW
 ap
 ap
@@ -17205,7 +17982,7 @@ ap
 ap
 ap
 pW
-IL
+Qr
 Qb
 Qw
 Qw
@@ -17214,11 +17991,11 @@ jo
 Qw
 Ry
 Qw
-Qw
+qE
 Qw
 Jw
 Nw
-lW
+xa
 lW
 rt
 rt
@@ -17227,7 +18004,7 @@ li
 OP
 dZ
 dZ
-dZ
+oO
 lB
 vo
 vo
@@ -17252,7 +18029,7 @@ cQ
 pF
 oR
 oR
-oR
+lH
 oR
 oR
 lH
@@ -17262,13 +18039,13 @@ EB
 It
 wO
 wO
-sD
+WV
 EB
-vK
+PF
 sC
-hU
+ba
 Gf
-tg
+Eh
 nA
 ud
 Fn
@@ -17277,7 +18054,7 @@ Sm
 XU
 tk
 Wl
-yF
+aB
 nt
 Vx
 ve
@@ -17303,11 +18080,11 @@ Wx
 Wt
 QB
 Xg
-kK
+Rg
 kK
 cw
 QB
-DU
+GI
 DU
 DU
 GI
@@ -17372,12 +18149,12 @@ lB
 Ut
 aZ
 eJ
+jw
+pj
+jw
 pj
 pj
-pj
-pj
-pj
-pj
+jw
 du
 pj
 pj
@@ -17424,7 +18201,7 @@ oP
 Ul
 Ke
 Ke
-yc
+UY
 oP
 Sn
 QB
@@ -17459,10 +18236,10 @@ LV
 LV
 LV
 Xy
+wE
 Xy
 Xy
-Xy
-Xy
+wE
 Xy
 LV
 LV
@@ -17471,7 +18248,7 @@ LV
 pW
 LK
 sM
-Wc
+tz
 Wc
 Wc
 jo
@@ -17485,22 +18262,22 @@ pW
 Xy
 XB
 rt
-rt
+ev
 rt
 li
-OP
+ew
 dZ
 dZ
 dZ
-lB
+LN
 yP
 Bw
 Cd
-OP
+ew
 dZ
 dZ
 dZ
-lB
+LN
 Ut
 yf
 ax
@@ -17523,7 +18300,7 @@ Tc
 Tc
 rt
 rt
-rt
+ev
 wO
 wO
 rt
@@ -17537,7 +18314,7 @@ gD
 SN
 Fn
 in
-in
+MC
 yF
 yF
 Mv
@@ -17607,7 +18384,7 @@ Qw
 Qw
 Qw
 jo
-Qw
+qE
 ja
 dP
 ja
@@ -17662,7 +18439,7 @@ rt
 EB
 Qp
 sC
-hU
+ba
 Gf
 tg
 SZ
@@ -17674,16 +18451,16 @@ XU
 zM
 qL
 yF
-nt
+Pa
 Vx
 DU
 DU
 Py
-hX
+qb
 hX
 hX
 Xh
-hX
+qb
 hX
 hX
 kT
@@ -17693,19 +18470,19 @@ wJ
 Fk
 OI
 kK
-kK
+Rg
 Lq
 kK
 kK
 kK
 rA
 Zi
-Rg
+kK
 Ag
 LR
 DU
 DU
-DU
+GI
 DU
 DU
 DU
@@ -17792,7 +18569,7 @@ wO
 Sg
 rt
 jY
-DU
+GI
 Fn
 Fn
 Fn
@@ -17809,7 +18586,7 @@ ee
 JQ
 XU
 lq
-DU
+GI
 DU
 LT
 hX
@@ -17821,7 +18598,7 @@ hX
 Or
 Ky
 tS
-hX
+qb
 sH
 iX
 iX
@@ -17840,7 +18617,7 @@ DU
 DU
 DU
 DU
-DU
+GI
 DU
 DU
 lq
@@ -17865,7 +18642,7 @@ LV
 LV
 LV
 pW
-IL
+Qr
 Qb
 gk
 Qw
@@ -17886,7 +18663,7 @@ rt
 li
 OP
 dZ
-dZ
+oO
 dZ
 Ne
 Bw
@@ -17894,7 +18671,7 @@ lS
 Bw
 fr
 zy
-dZ
+oO
 dZ
 ql
 li
@@ -17903,7 +18680,7 @@ BQ
 NY
 By
 SO
-PB
+WW
 jh
 Gr
 vC
@@ -17927,12 +18704,12 @@ rt
 DU
 Fn
 Vt
-hI
+gz
 nA
 SZ
 ZE
 Fn
-in
+MC
 in
 Co
 XU
@@ -17991,7 +18768,7 @@ GT
 wE
 Xy
 XB
-dA
+um
 sU
 wV
 XB
@@ -18005,14 +18782,14 @@ UA
 jo
 qE
 Qw
+qE
 Qw
 Qw
-Qw
-jG
+wx
 pW
 Xy
 SW
-bG
+Rf
 EB
 jI
 li
@@ -18041,7 +18818,7 @@ BQ
 BQ
 IY
 CU
-AO
+vA
 Fm
 Bg
 dJ
@@ -18077,7 +18854,7 @@ lq
 lq
 DU
 jE
-Fx
+as
 Fx
 Fx
 Im
@@ -18127,7 +18904,7 @@ dA
 Tq
 ym
 Xy
-Xy
+wE
 Nw
 IL
 Qb
@@ -18188,7 +18965,7 @@ tP
 Fm
 rt
 rt
-DU
+GI
 Fn
 Fn
 Fn
@@ -18211,27 +18988,27 @@ lq
 lq
 Gw
 DU
-ve
 DU
 DU
 DU
+GI
 DU
 tS
 qb
 Sw
 DU
-DU
+GI
 QB
 dL
 If
 iQ
 Ug
 iX
-kK
+Rg
 Wt
 QB
 QB
-DU
+GI
 DU
 DU
 DU
@@ -18289,7 +19066,7 @@ uS
 ey
 ey
 bG
-EB
+fk
 EB
 EB
 sD
@@ -18298,7 +19075,7 @@ EB
 vC
 gR
 xb
-SO
+Ox
 SO
 xb
 xb
@@ -18326,15 +19103,15 @@ vT
 Du
 Gp
 Qp
-Qp
+cb
 Qp
 DU
-DU
+GI
 Qp
 Du
 Gp
 kY
-DU
+GI
 DU
 DU
 lq
@@ -18343,7 +19120,7 @@ lq
 lq
 DU
 DU
-DU
+GI
 DU
 NP
 DU
@@ -18370,7 +19147,7 @@ DU
 kY
 qJ
 mz
-Ru
+ez
 Ru
 lq
 QU
@@ -18408,10 +19185,10 @@ aV
 pW
 Xy
 Xy
-jY
+WG
 tr
 rt
-rt
+ev
 rt
 rt
 jY
@@ -18425,7 +19202,7 @@ It
 EB
 tr
 EB
-sD
+WV
 EB
 BQ
 BQ
@@ -18435,7 +19212,7 @@ tt
 cZ
 BQ
 BQ
-ry
+aN
 Jy
 AO
 nM
@@ -18497,7 +19274,7 @@ QB
 DU
 DU
 DU
-DU
+GI
 DU
 DU
 DU
@@ -18517,10 +19294,10 @@ LV
 LV
 LV
 ro
+wE
 Xy
 Xy
-Xy
-Xy
+wE
 Xy
 Xy
 wE
@@ -18571,7 +19348,7 @@ ry
 kp
 AO
 nM
-Ob
+lz
 Bg
 Wq
 fI
@@ -18612,7 +19389,7 @@ Jt
 Jd
 Jt
 Jd
-tS
+IK
 hX
 sH
 UL
@@ -18665,7 +19442,7 @@ Qw
 ae
 NA
 Qw
-Qw
+qE
 Qw
 Uw
 mL
@@ -18681,7 +19458,7 @@ rt
 rt
 rt
 jY
-rt
+ev
 rt
 rt
 jY
@@ -18731,7 +19508,7 @@ Zy
 Zl
 Jd
 Qu
-Qu
+yL
 Qu
 Jd
 Zl
@@ -18759,7 +19536,7 @@ Ku
 xo
 QB
 OQ
-kY
+lM
 DU
 DU
 GI
@@ -18792,18 +19569,18 @@ Nw
 Bu
 ec
 JO
-Qw
+qE
 sc
 ae
 Qw
 Qw
 sc
-Qw
+qE
 Uw
 Jw
 Nw
 Xy
-Xy
+wE
 rt
 Su
 Su
@@ -18832,7 +19609,7 @@ Tc
 Tc
 Tc
 ry
-kp
+ot
 AO
 Fm
 Fm
@@ -18869,7 +19646,7 @@ Jd
 Zl
 Ud
 Zl
-Ud
+Pf
 Ud
 Ud
 Zl
@@ -18884,7 +19661,7 @@ vh
 kK
 Fd
 bK
-vh
+gJ
 th
 Qt
 Vn
@@ -18972,9 +19749,9 @@ Bg
 Wq
 xM
 Wq
-dJ
+VK
 eR
-dJ
+VK
 bb
 Fm
 rt
@@ -18992,13 +19769,13 @@ Jd
 lA
 vj
 vj
-vj
+WK
 nz
 VA
 VA
 Qu
 Jt
-Ud
+Pf
 sJ
 Ud
 Ud
@@ -19031,7 +19808,7 @@ DU
 DU
 DU
 DU
-DU
+GI
 lq
 QU
 "}
@@ -19055,7 +19832,7 @@ lO
 pW
 Pb
 ec
-Qw
+qE
 sy
 hf
 zB
@@ -19064,7 +19841,7 @@ im
 ag
 ml
 Uw
-jG
+wx
 fa
 fa
 to
@@ -19113,7 +19890,7 @@ rt
 Tc
 Tc
 DU
-DU
+GI
 DU
 Jt
 Ud
@@ -19146,7 +19923,7 @@ vx
 LR
 vh
 kK
-kK
+Rg
 lV
 vh
 No
@@ -19185,13 +19962,13 @@ lO
 lO
 lO
 pW
-Pb
-qz
+QW
+ec
 Ry
 Ji
 Hm
 rF
-Qw
+qE
 Cp
 Ve
 fu
@@ -19214,7 +19991,7 @@ Su
 Su
 rt
 rt
-rt
+ev
 rt
 rt
 Su
@@ -19231,7 +20008,7 @@ ry
 kp
 AO
 Fm
-Ob
+lz
 Bg
 Wq
 Bg
@@ -19291,7 +20068,7 @@ lq
 lq
 lq
 DU
-DU
+GI
 DU
 DU
 DU
@@ -19320,7 +20097,7 @@ pW
 Pb
 ec
 JO
-Qw
+qE
 sc
 Qw
 Qw
@@ -19332,7 +20109,7 @@ Jw
 fa
 KJ
 pg
-pg
+mO
 VE
 fa
 Su
@@ -19360,7 +20137,7 @@ Su
 Su
 rm
 ry
-kp
+ot
 AO
 Fm
 pJ
@@ -19373,7 +20150,7 @@ XA
 rt
 rt
 rt
-rt
+ev
 rt
 rt
 DU
@@ -19459,7 +20236,7 @@ Qw
 Fc
 GH
 Uk
-Uw
+GE
 Jw
 fa
 KJ
@@ -19587,7 +20364,7 @@ Qw
 sy
 hf
 jZ
-Qw
+qE
 Ec
 ag
 jZ
@@ -19600,7 +20377,7 @@ kq
 mp
 to
 Fl
-Fl
+cy
 Ss
 yt
 yt
@@ -19610,7 +20387,7 @@ Su
 Su
 Su
 rt
-rt
+ev
 rt
 Su
 Su
@@ -19660,7 +20437,7 @@ MC
 in
 in
 in
-in
+MC
 in
 in
 in
@@ -19684,7 +20461,7 @@ QB
 QB
 lq
 lq
-DU
+GI
 DU
 DU
 DU
@@ -19715,7 +20492,7 @@ lO
 pW
 Pb
 ec
-Qw
+qE
 nc
 Ny
 fu
@@ -19747,7 +20524,7 @@ Fl
 Su
 Su
 dc
-rt
+ev
 rt
 dc
 dc
@@ -19776,13 +20553,13 @@ DU
 in
 in
 Qu
-Qu
+yL
 Qu
 yL
 Qu
 Qu
 Qu
-Qu
+yL
 Qu
 Qu
 Qu
@@ -19798,7 +20575,7 @@ sh
 sh
 sh
 sh
-sh
+Tf
 sh
 xl
 TF
@@ -19845,7 +20622,7 @@ lO
 lO
 lO
 pW
-Pb
+QW
 ec
 Qw
 qE
@@ -19853,10 +20630,10 @@ sc
 Qw
 Qw
 Qw
-sc
+bp
 Qw
 Qw
-Jw
+DW
 VE
 VE
 RW
@@ -19869,7 +20646,7 @@ cy
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Su
 Fl
@@ -19888,7 +20665,7 @@ Su
 Su
 Su
 bn
-kp
+ot
 nZ
 Fa
 Fa
@@ -19918,7 +20695,7 @@ Qu
 Qu
 Qu
 Qu
-sN
+jB
 in
 in
 in
@@ -19984,7 +20761,7 @@ Fc
 Vc
 zT
 Qw
-Fc
+cK
 Ya
 Uk
 Qw
@@ -20003,10 +20780,10 @@ mD
 mD
 mD
 Fl
+cy
 Fl
 Fl
-Fl
-Fl
+cy
 Fl
 Su
 Su
@@ -20027,7 +20804,7 @@ Fa
 dc
 dc
 rt
-rt
+ev
 rt
 rt
 Tc
@@ -20071,10 +20848,10 @@ GI
 DU
 DU
 DU
-yA
+Bn
 oX
 Eo
-Vp
+iE
 kL
 Xi
 Xi
@@ -20125,11 +20902,11 @@ fa
 fa
 fa
 lh
-VE
+RW
 mD
 vQ
 lF
-lF
+Os
 lF
 lF
 Qe
@@ -20146,7 +20923,7 @@ Su
 Su
 rt
 rt
-rt
+ev
 rt
 rt
 Su
@@ -20168,7 +20945,7 @@ Tc
 Tc
 Tc
 Tc
-DU
+GI
 DU
 DU
 Jd
@@ -20186,13 +20963,13 @@ in
 in
 ng
 Dc
-Rj
+tA
 Rj
 ng
 hX
 hX
 AU
-hX
+qb
 hX
 hX
 hx
@@ -20217,7 +20994,7 @@ Qp
 Co
 dv
 Qp
-kY
+lM
 Qp
 lq
 lq
@@ -20243,14 +21020,14 @@ lO
 pW
 Pb
 ec
-Qw
+qE
 FN
 Ny
 fu
 Qw
 mm
 VL
-fu
+IV
 Qw
 DW
 fa
@@ -20260,7 +21037,7 @@ pg
 VE
 mD
 wL
-rX
+av
 Rh
 pV
 rX
@@ -20314,7 +21091,7 @@ Zl
 Ud
 Zl
 Jd
-sg
+Ee
 in
 ng
 Rj
@@ -20340,13 +21117,13 @@ Xi
 XZ
 uk
 Vp
-uk
+BT
 nj
 In
 Xi
 OQ
 Qp
-qJ
+Hb
 os
 vT
 DU
@@ -20379,7 +21156,7 @@ He
 Xt
 nK
 nK
-nK
+DL
 nK
 Xt
 nB
@@ -20392,7 +21169,7 @@ pg
 mD
 mD
 je
-av
+Cy
 mD
 mD
 pS
@@ -20403,7 +21180,7 @@ Up
 Kv
 mD
 Fl
-Fl
+cy
 Fl
 Su
 Su
@@ -20416,7 +21193,7 @@ Su
 Su
 Su
 bn
-kp
+ot
 AO
 BU
 Fa
@@ -20433,12 +21210,12 @@ rt
 dc
 nW
 DU
-DU
+GI
 yO
 Jt
 Ud
 Ud
-Ud
+Pf
 Ud
 bX
 Ud
@@ -20448,11 +21225,11 @@ Ud
 SL
 Qu
 in
-MF
 Rj
+tA
 js
 GJ
-UI
+Rj
 hX
 hX
 Za
@@ -20528,7 +21305,7 @@ lv
 RX
 Fy
 rX
-ER
+Oh
 mD
 mD
 mD
@@ -20580,12 +21357,12 @@ Ud
 Ud
 QT
 in
-MF
+Rj
 lX
 es
 Rj
-UI
-hX
+Rj
+qb
 hX
 Nb
 bc
@@ -20614,7 +21391,7 @@ Qp
 DU
 DU
 DU
-DU
+GI
 DU
 DU
 QU
@@ -20655,10 +21432,10 @@ vu
 pu
 mD
 Vu
-rX
+Cy
 gB
 po
-tK
+cu
 QX
 rX
 Nl
@@ -20695,7 +21472,7 @@ Fa
 Fa
 rt
 rt
-rt
+ev
 DU
 DU
 Fa
@@ -20715,7 +21492,7 @@ in
 ng
 GJ
 lZ
-Rj
+tA
 ng
 hX
 hX
@@ -20726,16 +21503,16 @@ hX
 hx
 MJ
 hX
-yZ
+jR
 yO
 kA
 yO
-DU
+GI
 DU
 yO
 Xi
 Eu
-Eo
+lu
 BA
 Th
 Yq
@@ -20744,7 +21521,7 @@ JL
 Xi
 Qp
 Qp
-DU
+GI
 DU
 DU
 DU
@@ -20783,7 +21560,7 @@ Qw
 Zc
 VE
 VE
-pg
+mO
 hK
 mD
 kH
@@ -20799,7 +21576,7 @@ rX
 Zn
 Op
 lo
-Lk
+Mj
 Fl
 Ss
 Su
@@ -20843,7 +21620,7 @@ xi
 NF
 Jd
 in
-in
+MC
 ng
 Rj
 sW
@@ -20900,7 +21677,7 @@ lO
 lO
 lO
 Fl
-Fl
+cy
 pW
 Ns
 WI
@@ -20909,7 +21686,7 @@ dG
 WI
 cp
 WI
-WI
+qj
 WI
 gw
 WI
@@ -20950,7 +21727,7 @@ Lk
 Lk
 ZF
 Fl
-Fl
+cy
 Fl
 Ss
 Ss
@@ -21073,12 +21850,12 @@ Fl
 Ss
 Ss
 Ss
-Fl
+cy
 YU
 jV
 wN
 ea
-Lk
+Mj
 OV
 lo
 Fl
@@ -21088,7 +21865,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -21131,7 +21908,7 @@ Rw
 Rw
 wF
 iz
-pc
+ES
 bJ
 hT
 bJ
@@ -21188,7 +21965,7 @@ OD
 sd
 Wr
 mI
-mI
+KZ
 mI
 mI
 ul
@@ -21199,7 +21976,7 @@ mI
 fW
 fa
 Fl
-Fl
+cy
 Ss
 Ss
 Ss
@@ -21216,7 +21993,7 @@ Xd
 Fl
 Lk
 Lk
-ZF
+BX
 Lk
 Fl
 Fl
@@ -21295,16 +22072,16 @@ lO
 lO
 lO
 Fl
-Fl
+cy
 Fl
 pW
 Qw
 Qw
-Qw
+qE
 kR
 Qw
 Qw
-Qw
+qE
 Qw
 Qw
 kR
@@ -21317,7 +22094,7 @@ VE
 RW
 VE
 KJ
-KJ
+of
 KJ
 KJ
 fa
@@ -21344,7 +22121,7 @@ kI
 ea
 ef
 Lz
-sz
+ug
 Lk
 Lk
 Lk
@@ -21355,7 +22132,7 @@ Fl
 Fl
 Fl
 Fl
-Ss
+kF
 Fl
 Fa
 Fa
@@ -21385,7 +22162,7 @@ Pq
 Pq
 Pq
 fy
-hX
+qb
 eX
 Pq
 Pq
@@ -21442,7 +22219,7 @@ JP
 is
 no
 fa
-VE
+RW
 VE
 VE
 VE
@@ -21458,7 +22235,7 @@ KJ
 Aa
 KJ
 EE
-KJ
+of
 KJ
 KJ
 oa
@@ -21615,7 +22392,7 @@ Lk
 OV
 lo
 Lk
-Lk
+Mj
 ZF
 Wi
 YU
@@ -21635,15 +22412,15 @@ Tm
 Gu
 nk
 nk
-nk
+Fs
 nk
 nk
 nk
 RH
+cR
 Tm
 Tm
-Tm
-Tm
+cR
 Tm
 Tm
 Tm
@@ -21667,7 +22444,7 @@ sQ
 tN
 Xi
 xD
-Tm
+cR
 IQ
 be
 be
@@ -21690,7 +22467,7 @@ lO
 lO
 lO
 lO
-Fl
+cy
 Fl
 Fl
 pW
@@ -21710,7 +22487,7 @@ fa
 fa
 fa
 Fl
-Fl
+cy
 lO
 lO
 lO
@@ -21739,7 +22516,7 @@ jV
 wN
 ea
 YU
-Fl
+cy
 Nm
 Nm
 lj
@@ -21758,7 +22535,7 @@ zo
 Tm
 Tm
 IQ
-Yb
+nG
 Yb
 Pi
 Rd
@@ -21778,7 +22555,7 @@ sB
 sB
 TD
 TD
-Tm
+cR
 Tm
 JR
 Nk
@@ -21850,7 +22627,7 @@ lO
 lO
 eY
 vn
-rT
+Al
 FY
 FY
 FY
@@ -21862,7 +22639,7 @@ jV
 pE
 pE
 pE
-pE
+vv
 pE
 pE
 ea
@@ -21894,7 +22671,7 @@ Oa
 Yb
 Yb
 aQ
-sF
+gL
 Oa
 HU
 Iq
@@ -21918,7 +22695,7 @@ Nk
 cT
 on
 Nk
-QQ
+rY
 Xi
 Tl
 ih
@@ -21933,10 +22710,10 @@ qD
 dC
 Xi
 sF
+nG
 Yb
 Yb
-Yb
-Tm
+cR
 zL
 "}
 (90,1,1) = {"
@@ -21958,15 +22735,15 @@ Fl
 Fl
 Fl
 Fl
+cy
 Fl
 Fl
 Fl
-Fl
-Fl
+cy
 Fl
 Lk
 Lk
-ef
+qk
 sz
 Lk
 Lk
@@ -21984,7 +22761,7 @@ eY
 FY
 FY
 rC
-FY
+iM
 rC
 FY
 FY
@@ -21998,7 +22775,7 @@ Kt
 Kt
 Kt
 zG
-YU
+hC
 jV
 wN
 ea
@@ -22006,11 +22783,11 @@ Fl
 Fl
 Nm
 UH
-XQ
+AC
 JE
 Nm
 rg
-Fl
+cy
 Fl
 Fq
 kz
@@ -22022,7 +22799,7 @@ UU
 UU
 Tm
 Tm
-Tm
+cR
 Tm
 Yb
 aQ
@@ -22039,7 +22816,7 @@ Nn
 dM
 dn
 BS
-BS
+uU
 BS
 BS
 BS
@@ -22053,7 +22830,7 @@ Nk
 Nf
 oX
 Eo
-Eo
+lu
 uj
 uj
 Ma
@@ -22128,7 +22905,7 @@ cy
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 jV
@@ -22152,7 +22929,7 @@ UU
 UU
 UU
 UU
-Tm
+cR
 Tm
 Yb
 Yb
@@ -22160,7 +22937,7 @@ Oa
 jW
 Hw
 dx
-HU
+Je
 Iq
 Iq
 Ah
@@ -22188,7 +22965,7 @@ Eo
 fH
 FM
 iJ
-Eo
+lu
 Eo
 lu
 Eo
@@ -22221,14 +22998,14 @@ lO
 lO
 lO
 lO
+cy
 Fl
 Fl
 Fl
 Fl
 Fl
 Fl
-Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22237,7 +23014,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22253,7 +23030,7 @@ cn
 NS
 Ka
 eY
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22273,7 +23050,7 @@ wl
 XQ
 LP
 ss
-ss
+dY
 fb
 Nm
 lO
@@ -22303,7 +23080,7 @@ dI
 qT
 Ce
 ny
-oy
+bY
 TD
 qT
 bY
@@ -22312,7 +23089,7 @@ NG
 Nk
 ZW
 cT
-Nk
+uC
 Nk
 QQ
 Xi
@@ -22331,7 +23108,7 @@ oX
 Yb
 wf
 rd
-Tm
+cR
 Tm
 zL
 "}
@@ -22364,7 +23141,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 aR
 Fl
@@ -22399,10 +23176,10 @@ jV
 kZ
 Sq
 lj
-xm
+YY
 XQ
 XQ
-XQ
+AC
 Nm
 py
 XQ
@@ -22416,7 +23193,7 @@ UU
 Tm
 Tm
 Tm
-Tm
+cR
 Tm
 Tm
 tG
@@ -22432,7 +23209,7 @@ QF
 Tx
 Tx
 oQ
-qT
+HP
 hG
 ny
 qT
@@ -22499,7 +23276,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22525,7 +23302,7 @@ lO
 lO
 lO
 Fl
-Fl
+cy
 Fl
 tc
 fE
@@ -22553,7 +23330,7 @@ Tm
 Tm
 Tm
 zo
-Tm
+cR
 Tm
 zo
 Tm
@@ -22592,7 +23369,7 @@ ct
 Eo
 Io
 Xi
-Tm
+cR
 Tm
 Tm
 Tm
@@ -22625,7 +23402,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22643,14 +23420,14 @@ Fl
 eY
 Ys
 Vy
-RD
+EX
 eY
 Ys
-Vy
+DB
 RD
 eY
 Fl
-Fl
+cy
 Fl
 lO
 lO
@@ -22679,7 +23456,7 @@ lO
 UU
 Tm
 Tm
-Tm
+cR
 UU
 UU
 xD
@@ -22700,12 +23477,12 @@ qT
 IX
 Wo
 ND
-IX
+aC
 Wo
 ND
 TD
 Xc
-Nk
+uC
 Nk
 cT
 nT
@@ -22719,7 +23496,7 @@ Xi
 GY
 Ja
 Eo
-Eo
+lu
 Eo
 Ja
 Io
@@ -22749,7 +23526,7 @@ lO
 lO
 lO
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -22820,13 +23597,13 @@ UU
 UU
 Tm
 Tm
-Tm
+cR
 Tm
 UU
 TD
 uB
 Xl
-qT
+HP
 qT
 HP
 AM
@@ -22845,7 +23622,7 @@ Nk
 hP
 Tm
 Tm
-Tm
+cR
 Tm
 Xi
 Wg
@@ -22901,7 +23678,7 @@ lO
 lO
 lO
 Fl
-Fl
+cy
 Fl
 Fl
 cy
@@ -22934,7 +23711,7 @@ Nm
 Nm
 LJ
 jt
-BE
+HH
 hs
 oC
 Nm
@@ -22970,7 +23747,7 @@ kl
 TD
 yU
 ZM
-ZM
+mY
 ZM
 ZM
 bv
@@ -23027,7 +23804,7 @@ PS
 PS
 Fl
 Fl
-Fl
+cy
 lO
 lO
 lO
@@ -23040,13 +23817,13 @@ Fl
 Fl
 Fl
 Fl
+cy
 Fl
 Fl
 Fl
 Fl
 Fl
-Fl
-Fl
+cy
 Fl
 lO
 lO
@@ -23073,7 +23850,7 @@ Nm
 lO
 lO
 Tm
-Tm
+cR
 Tm
 Tm
 UU
@@ -23106,7 +23883,7 @@ Tm
 Tm
 Tm
 AZ
-Tm
+cR
 Tm
 Tm
 Tm
@@ -23145,7 +23922,7 @@ PS
 PS
 cr
 cr
-cr
+iI
 cr
 st
 cr
@@ -23281,7 +24058,7 @@ Cc
 cr
 cr
 cr
-cr
+iI
 PS
 PS
 PS
@@ -23326,16 +24103,16 @@ lj
 xm
 hw
 XQ
-XQ
+AC
 vq
 Zd
 Bv
 Nm
+cy
 Fl
 Fl
 Fl
 Fl
-Fl
 Tm
 Tm
 Tm
@@ -23352,17 +24129,17 @@ UU
 UU
 UU
 Tm
+cR
 Tm
 Tm
-Tm
-Tm
+cR
 Tm
 Tm
 te
 Pz
 te
 te
-te
+Pz
 Tm
 Tm
 ol
@@ -23379,7 +24156,7 @@ cR
 Tm
 Tm
 Tm
-Tm
+cR
 Tm
 mR
 mR
@@ -23423,19 +24200,19 @@ PS
 PS
 PS
 aR
-Fl
+cy
 Fl
 Fl
 Fl
 aR
 Fl
 Fl
+cy
 Fl
 Fl
 Fl
 Fl
-Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -23453,7 +24230,7 @@ Fl
 CK
 zk
 Fl
-Fl
+cy
 Nm
 qB
 Hy
@@ -23470,7 +24247,7 @@ Fl
 Fl
 Tm
 zo
-Tm
+cR
 UU
 UU
 UU
@@ -23504,7 +24281,7 @@ vk
 gN
 FD
 Jl
-Tm
+cR
 Tm
 Tm
 Tm
@@ -23574,7 +24351,7 @@ sx
 Fl
 Fl
 aR
-Fl
+cy
 Fl
 Fl
 Fl
@@ -23588,7 +24365,7 @@ Fl
 Gl
 lj
 CT
-KH
+TL
 mT
 vg
 VQ
@@ -23618,7 +24395,7 @@ Tm
 Tm
 Tm
 Tm
-Tm
+cR
 Tm
 Tm
 aA
@@ -23710,7 +24487,7 @@ aR
 Fl
 Fl
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -23738,7 +24515,7 @@ Tm
 Tm
 Tm
 Yb
-Yb
+nG
 jW
 Hw
 Hw
@@ -23746,7 +24523,7 @@ dx
 Yb
 Tm
 Tm
-Tm
+cR
 Tm
 Tm
 Tm
@@ -23757,11 +24534,11 @@ mW
 sT
 BN
 ia
-VV
+wu
 el
 Dg
 Tm
-Tm
+cR
 PD
 Yg
 HB
@@ -23806,7 +24583,7 @@ sl
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 cr
@@ -23818,14 +24595,14 @@ PS
 PS
 PS
 PS
+WR
 MN
 MN
 MN
 MN
 MN
 MN
-MN
-MN
+WR
 sx
 sx
 sx
@@ -23835,7 +24612,7 @@ sx
 sx
 sx
 sx
-Fl
+cy
 Fl
 Fl
 Fl
@@ -23857,10 +24634,10 @@ XQ
 XQ
 vq
 Dm
-Bv
+iv
 Nm
 Fl
-Fl
+cy
 Fl
 Fl
 Fl
@@ -23873,7 +24650,7 @@ Yb
 Yb
 Yb
 Oa
-Yb
+nG
 Tm
 IQ
 Tm
@@ -24020,13 +24797,13 @@ Tm
 mW
 sT
 BN
-ia
+EA
 BN
 Hn
 VV
 Af
 Tm
-Tm
+cR
 FD
 KF
 Kb
@@ -24034,7 +24811,7 @@ FD
 Cr
 Tm
 Tm
-Tm
+cR
 mR
 mR
 mR
@@ -24101,10 +24878,10 @@ sx
 sx
 sx
 Fl
+Mj
 Lk
 Lk
-Lk
-Lk
+Mj
 Fl
 Fl
 YU
@@ -24113,7 +24890,7 @@ Fl
 Fl
 Fl
 Fl
-Fl
+cy
 Nm
 Nm
 lj
@@ -24128,9 +24905,9 @@ Fl
 Fl
 Fl
 Fl
-zo
+wZ
 Tm
-Tm
+cR
 Tm
 Tm
 zo
@@ -24205,7 +24982,7 @@ iI
 cr
 cr
 cr
-cr
+iI
 yi
 PS
 PS
@@ -24217,7 +24994,7 @@ PS
 PS
 PS
 MN
-MN
+WR
 MN
 MN
 MN
@@ -24241,7 +25018,7 @@ Lk
 Lk
 Lk
 Fl
-Fl
+cy
 Fl
 Fl
 aR
@@ -24273,14 +25050,14 @@ Tm
 An
 Tm
 kb
+cR
 Tm
 Tm
 Tm
 Tm
 Tm
 Tm
-Tm
-Tm
+cR
 Tm
 ce
 df
@@ -24329,7 +25106,7 @@ PS
 PS
 PS
 PS
-cr
+iI
 Um
 cr
 cr
@@ -24420,7 +25197,7 @@ te
 UG
 te
 Tm
-VR
+Db
 Tm
 EH
 up
@@ -24433,7 +25210,7 @@ GN
 GN
 GN
 GN
-GN
+DN
 GN
 mR
 mR
@@ -24512,7 +25289,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 MN
 sx
 sx
@@ -24560,7 +25337,7 @@ Tm
 Tm
 GN
 GN
-GN
+DN
 GN
 DN
 GN
@@ -24604,7 +25381,7 @@ Um
 Um
 Um
 cr
-cr
+iI
 cr
 cr
 cr
@@ -24677,17 +25454,17 @@ UU
 UU
 Tm
 Tm
+cR
 Tm
 Tm
-Tm
-Tm
+cR
 Tm
 Tm
 cR
 Tm
 Tm
 Tm
-Tm
+cR
 Tm
 Tm
 mR
@@ -24734,7 +25511,7 @@ cr
 cr
 cr
 Aj
-cr
+iI
 cr
 cr
 cr
@@ -24774,12 +25551,12 @@ sx
 sx
 MN
 MN
+WR
 MN
 MN
 MN
 MN
-MN
-MN
+WR
 MN
 sx
 sx
@@ -24860,7 +25637,7 @@ cr
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 PS
@@ -24959,7 +25736,7 @@ mR
 mR
 mR
 GN
-GN
+DN
 GN
 GN
 aH
@@ -24988,7 +25765,7 @@ PS
 PS
 PS
 cr
-cr
+iI
 cr
 cr
 cr
@@ -25096,7 +25873,7 @@ GN
 Gd
 GN
 GN
-GN
+DN
 mR
 mR
 mR
@@ -25145,7 +25922,7 @@ sx
 sx
 MN
 MN
-MN
+WR
 MN
 MN
 sx
@@ -25178,7 +25955,7 @@ MN
 WR
 MN
 MN
-MN
+WR
 sx
 sx
 sx
@@ -25269,8 +26046,8 @@ PS
 PS
 PS
 cr
+iI
 cr
-cr
 sx
 sx
 sx
@@ -25302,7 +26079,7 @@ sx
 sx
 sx
 MN
-MN
+WR
 MN
 MN
 MN
@@ -25459,7 +26236,7 @@ mR
 mR
 Wh
 GN
-GN
+DN
 GN
 GN
 GN
@@ -25468,7 +26245,7 @@ cY
 GN
 GN
 GN
-GN
+DN
 GN
 GN
 sR
@@ -25617,11 +26394,11 @@ mR
 mR
 GN
 GN
-GN
+DN
 GN
 mR
 GN
-GN
+DN
 GN
 GN
 GN
@@ -25703,10 +26480,10 @@ sx
 sx
 sx
 sx
+WR
 MN
 MN
-MN
-MN
+WR
 MN
 sx
 sx
@@ -25726,14 +26503,14 @@ GN
 XO
 GN
 GN
+DN
 GN
 GN
 GN
 GN
 GN
 GN
-GN
-GN
+DN
 GN
 sR
 mR
@@ -25780,7 +26557,7 @@ PS
 PS
 cr
 cr
-cr
+iI
 cr
 cr
 cr
@@ -25797,17 +26574,17 @@ PS
 PS
 PS
 cr
+iI
 cr
-cr
+MN
+WR
 MN
 MN
 MN
 MN
 MN
 MN
-MN
-MN
-MN
+WR
 MN
 sx
 sx
@@ -25916,7 +26693,7 @@ cr
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 PS
@@ -25947,9 +26724,9 @@ MN
 Px
 MN
 MN
+WR
 MN
 MN
-MN
 sx
 sx
 sx
@@ -25960,7 +26737,7 @@ sx
 sx
 sx
 sx
-MN
+WR
 MN
 MN
 sx
@@ -25991,7 +26768,7 @@ GN
 DN
 GN
 GN
-GN
+DN
 GN
 mR
 mR
@@ -26106,7 +26883,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 MN
 sx
 mR
@@ -26144,12 +26921,12 @@ mR
 mR
 mR
 GN
-GN
+DN
 GN
 mR
 mR
 mR
-GN
+DN
 GN
 GN
 mR
@@ -26174,7 +26951,7 @@ PS
 PS
 PS
 PS
-cr
+iI
 cr
 cr
 cr
@@ -26233,7 +27010,7 @@ sx
 sx
 sx
 MN
-MN
+WR
 MN
 MN
 MN
@@ -26309,7 +27086,7 @@ PS
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 cr
@@ -26331,7 +27108,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 MN
 sx
 sx
@@ -26349,7 +27126,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 MN
 Px
 MN
@@ -26385,11 +27162,11 @@ GN
 GN
 GN
 GN
+DN
 GN
 GN
 GN
-GN
-GN
+DN
 GN
 GN
 GN
@@ -26415,7 +27192,7 @@ GN
 GN
 GN
 GN
-GN
+DN
 mR
 mR
 mR
@@ -26500,7 +27277,7 @@ MN
 MN
 MN
 WR
-WR
+MN
 MN
 MN
 MN
@@ -26531,7 +27308,7 @@ mR
 mR
 GN
 GN
-GN
+DN
 GN
 mR
 mR
@@ -26579,7 +27356,7 @@ cr
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 cr
@@ -26628,14 +27405,14 @@ MN
 MN
 MN
 MN
+WR
 MN
 MN
 MN
 MN
 MN
 MN
-MN
-MN
+WR
 MN
 GN
 GN
@@ -26647,7 +27424,7 @@ GN
 GN
 GN
 GN
-GN
+DN
 GN
 GN
 GN
@@ -26660,7 +27437,7 @@ GN
 GN
 GN
 mR
-GN
+DN
 GN
 GN
 GN
@@ -26669,7 +27446,7 @@ GN
 GN
 mR
 GN
-GN
+DN
 GN
 GN
 GN
@@ -26718,14 +27495,14 @@ cr
 cr
 cr
 cr
+iI
 cr
 cr
+iI
 cr
-cr
-cr
 MN
 MN
-MN
+WR
 MN
 MN
 sx
@@ -26735,7 +27512,7 @@ sx
 sx
 sx
 MN
-MN
+WR
 MN
 MN
 sx
@@ -26776,13 +27553,13 @@ GN
 GN
 GN
 GN
+DN
 GN
 GN
 GN
 GN
 GN
-GN
-GN
+DN
 GN
 GN
 DN
@@ -26795,10 +27572,10 @@ Gd
 GN
 GN
 GN
+DN
 GN
 GN
-GN
-GN
+DN
 GN
 GN
 Gd
@@ -26808,7 +27585,7 @@ GN
 GN
 GN
 GN
-GN
+DN
 Gd
 GN
 mR
@@ -26845,7 +27622,7 @@ cr
 cr
 cr
 cr
-cr
+iI
 cr
 cr
 cr
@@ -26886,6 +27663,7 @@ MN
 MN
 MN
 MN
+WR
 MN
 MN
 MN
@@ -26894,8 +27672,7 @@ MN
 MN
 MN
 MN
-MN
-MN
+WR
 MN
 MN
 sx
@@ -26903,7 +27680,7 @@ MN
 MN
 GN
 GN
-GN
+DN
 GN
 GN
 DN
@@ -26937,7 +27714,7 @@ GN
 GN
 GN
 GN
-GN
+DN
 GN
 GN
 GN
@@ -26992,7 +27769,7 @@ sx
 MN
 MN
 Px
-MN
+WR
 MN
 MN
 MN
@@ -27024,7 +27801,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 Px
 MN
 MN
@@ -27051,7 +27828,7 @@ mR
 mR
 GN
 GN
-GN
+DN
 GN
 GN
 GN
@@ -27063,7 +27840,7 @@ mR
 mR
 GN
 GN
-GN
+DN
 GN
 GN
 DN
@@ -27106,7 +27883,7 @@ PS
 PS
 PS
 PS
-Lb
+VB
 Lb
 Lb
 Lb
@@ -27128,7 +27905,7 @@ MN
 MN
 MN
 MN
-MN
+WR
 MN
 MN
 MN
@@ -27188,13 +27965,13 @@ GN
 GN
 GN
 GN
-GN
+DN
 mR
 mR
 mR
 mR
 mR
-GN
+DN
 GN
 GN
 GN
@@ -27276,7 +28053,7 @@ sx
 Fg
 Fg
 MN
-MN
+WR
 sx
 sx
 sx
@@ -27298,7 +28075,7 @@ sx
 sx
 sx
 mR
-zi
+aM
 zi
 zi
 mR
@@ -27459,7 +28236,7 @@ mR
 mR
 mR
 GN
-GN
+DN
 GN
 mR
 mR
@@ -27552,7 +28329,7 @@ sx
 sx
 sx
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -27565,9 +28342,9 @@ zi
 zi
 zi
 Qz
+aM
 zi
 zi
-zi
 mR
 mR
 mR
@@ -27579,7 +28356,7 @@ mR
 mR
 mR
 mR
-GN
+DN
 GN
 GN
 GN
@@ -27714,7 +28491,7 @@ mR
 GN
 GN
 GN
-GN
+DN
 GN
 zi
 zi
@@ -27803,7 +28580,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 sx
 sx
 sx
@@ -27833,7 +28610,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 mR
 mR
 mR
@@ -27848,10 +28625,10 @@ mR
 mR
 GN
 zi
-zi
+aM
 zi
 AR
-zi
+aM
 zi
 aM
 zi
@@ -27905,7 +28682,7 @@ Lb
 VB
 Lb
 Lb
-Lb
+VB
 PS
 PS
 PS
@@ -27932,10 +28709,10 @@ sx
 sx
 sx
 Fg
+qP
 Fg
 Fg
 Fg
-Fg
 sx
 sx
 sx
@@ -27949,7 +28726,7 @@ sx
 sx
 Fg
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -28086,7 +28863,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 sx
 mR
@@ -28098,7 +28875,7 @@ mR
 zi
 zi
 zi
-zi
+aM
 zi
 mR
 mR
@@ -28164,7 +28941,7 @@ PS
 PS
 PS
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -28177,7 +28954,7 @@ PS
 PS
 sx
 ua
-Fg
+qP
 Fg
 Fg
 Fg
@@ -28245,7 +29022,7 @@ BH
 mR
 mR
 mR
-zi
+aM
 zi
 Wh
 zi
@@ -28315,7 +29092,7 @@ qP
 Fg
 Fg
 Fg
-Fg
+qP
 ua
 sx
 sx
@@ -28342,7 +29119,7 @@ sx
 sx
 sx
 sx
-Fg
+qP
 Fg
 Fg
 vI
@@ -28460,7 +29237,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -28481,10 +29258,10 @@ Fg
 Fg
 Fg
 Fg
+qP
 Fg
 Fg
-Fg
-Fg
+qP
 mR
 mR
 mR
@@ -28514,7 +29291,7 @@ zi
 Wh
 zi
 zi
-zi
+aM
 zi
 mR
 mR
@@ -28549,7 +29326,7 @@ jv
 Lb
 Lb
 Lb
-Lb
+VB
 jv
 Lb
 PS
@@ -28561,7 +29338,7 @@ PS
 PS
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -28571,7 +29348,7 @@ Lb
 VB
 Lb
 Lb
-Fg
+qP
 YL
 YL
 YL
@@ -28629,14 +29406,14 @@ zi
 zi
 zi
 zi
-zi
+aM
 mR
 mR
 mR
 mR
 zi
 zi
-zi
+aM
 Wh
 zi
 zi
@@ -28751,17 +29528,17 @@ Fg
 Fg
 zi
 zi
+aM
 zi
 zi
 zi
 zi
-zi
-zi
+aM
 zi
 zi
 zi
 Qz
-aM
+zi
 zi
 zi
 zi
@@ -28842,14 +29619,14 @@ qP
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 qP
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Ed
@@ -28941,7 +29718,7 @@ PS
 PS
 PS
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -28962,7 +29739,7 @@ Lb
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 PS
@@ -28985,22 +29762,8 @@ Fg
 Fg
 qV
 Fg
+qP
 Fg
-Fg
-sx
-sx
-sx
-sx
-Fg
-Fg
-Fg
-sx
-sx
-sx
-sx
-sx
-sx
-sx
 sx
 sx
 sx
@@ -29008,6 +29771,20 @@ sx
 Fg
 Fg
 Fg
+sx
+sx
+sx
+sx
+sx
+sx
+sx
+sx
+sx
+sx
+sx
+Fg
+Fg
+qP
 Fg
 Fg
 Fg
@@ -29025,11 +29802,11 @@ mR
 zi
 zi
 zi
+aM
 zi
 zi
 zi
-zi
-zi
+aM
 zi
 zi
 Qz
@@ -29046,7 +29823,7 @@ zi
 aM
 Qz
 zi
-zi
+aM
 zi
 zi
 zi
@@ -29148,14 +29925,14 @@ sx
 mR
 mR
 zi
-zi
+aM
 zi
 mR
 mR
 mR
 mR
 zi
-zi
+aM
 zi
 zi
 zi
@@ -29167,11 +29944,12 @@ zi
 zi
 Wh
 zi
-zi
+aM
 zi
 zi
 zi
 Wh
+aM
 zi
 zi
 zi
@@ -29181,8 +29959,7 @@ zi
 zi
 zi
 zi
-zi
-zi
+aM
 zi
 zi
 mR
@@ -29233,7 +30010,7 @@ PS
 PS
 sx
 sx
-Fg
+qP
 sx
 sx
 sx
@@ -29241,7 +30018,7 @@ sx
 sx
 sx
 Fg
-Fg
+qP
 sx
 sx
 sx
@@ -29256,7 +30033,7 @@ sx
 sx
 sx
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -29323,7 +30100,7 @@ mR
 zi
 zi
 zi
-zi
+aM
 zi
 mR
 mR
@@ -29344,6 +30121,7 @@ Lb
 Lb
 Lb
 Lb
+VB
 Lb
 Lb
 Lb
@@ -29352,8 +30130,7 @@ Lb
 Lb
 Lb
 Lb
-Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -29426,7 +30203,7 @@ mR
 mR
 mR
 zi
-zi
+aM
 zi
 zi
 zi
@@ -29478,7 +30255,7 @@ PS
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -29512,6 +30289,13 @@ sx
 sx
 Fg
 Fg
+qP
+Fg
+Fg
+sx
+sx
+sx
+sx
 Fg
 Fg
 Fg
@@ -29519,13 +30303,6 @@ sx
 sx
 sx
 sx
-Fg
-Fg
-Fg
-sx
-sx
-sx
-sx
 sx
 sx
 sx
@@ -29581,7 +30358,7 @@ mR
 mR
 zi
 zi
-zi
+aM
 zi
 zi
 aM
@@ -29619,7 +30396,7 @@ PS
 PS
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 PS
@@ -29683,7 +30460,7 @@ mR
 mR
 mR
 zi
-zi
+aM
 zi
 mR
 mR
@@ -29876,21 +30653,21 @@ PS
 Lb
 Lb
 Lb
-Lb
-Lb
-Lb
-PS
-PS
-PS
-Lb
-Lb
+VB
 Lb
 Lb
 PS
 PS
 PS
+Lb
+Lb
+Lb
+Lb
 PS
 PS
+PS
+PS
+PS
 sx
 sx
 sx
@@ -29978,7 +30755,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 zi
 zi
 zi
@@ -30005,7 +30782,7 @@ PS
 PS
 PS
 PS
-Lb
+VB
 Lb
 Lb
 Lb
@@ -30042,7 +30819,7 @@ sx
 sx
 gG
 Fg
-Fg
+qP
 gG
 Fg
 Fg
@@ -30091,7 +30868,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 mR
 mR
 mR
@@ -30116,7 +30893,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 mR
 mR
 mR
@@ -30211,7 +30988,7 @@ mR
 mR
 mR
 zi
-zi
+aM
 zi
 aM
 zi
@@ -30237,7 +31014,7 @@ mR
 mR
 zi
 Qz
-zi
+aM
 zi
 zi
 Qz
@@ -30309,7 +31086,7 @@ sx
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -30328,7 +31105,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -30353,7 +31130,7 @@ mR
 zi
 zi
 zi
-zi
+aM
 zi
 zi
 mR
@@ -30377,7 +31154,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 zi
 zi
 zi
@@ -30539,7 +31316,7 @@ PS
 jv
 Lb
 Lb
-Lb
+VB
 jv
 PS
 PS
@@ -30586,9 +31363,9 @@ sx
 ua
 sx
 sx
+qP
 Fg
-Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -30611,10 +31388,10 @@ zi
 zi
 zi
 zi
-zi
+aM
 mR
 mR
-zi
+aM
 zi
 zi
 zi
@@ -30669,7 +31446,7 @@ sl
 sl
 sl
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -30727,7 +31504,7 @@ qP
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 mR
 mR
@@ -30739,7 +31516,7 @@ mR
 mR
 mR
 zi
-zi
+aM
 zi
 zi
 zi
@@ -30764,7 +31541,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 zi
 mR
 mR
@@ -30829,7 +31606,7 @@ sx
 sx
 sx
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -30922,7 +31699,7 @@ sl
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -31073,7 +31850,7 @@ Lb
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -31081,7 +31858,7 @@ Lb
 Lb
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -31116,11 +31893,11 @@ sx
 sx
 sx
 Fg
+qP
 Fg
-Fg
 lP
 lP
-lP
+iF
 lP
 lP
 Fg
@@ -31136,7 +31913,7 @@ zi
 zi
 zi
 zi
-zi
+aM
 Qz
 zi
 AR
@@ -31153,12 +31930,12 @@ mR
 mR
 mR
 zi
+aM
 zi
 zi
 zi
 zi
-zi
-zi
+aM
 zi
 zi
 mR
@@ -31184,7 +31961,7 @@ LZ
 PS
 sl
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -31222,7 +31999,7 @@ qP
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 qP
@@ -31239,7 +32016,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 sx
@@ -31255,7 +32032,7 @@ lP
 lP
 lP
 lP
-Fg
+qP
 Fg
 zi
 zi
@@ -31276,12 +32053,12 @@ mR
 mR
 zi
 zi
-zi
+aM
 zi
 Qz
 zi
 zi
-zi
+aM
 zi
 zi
 Qz
@@ -31485,7 +32262,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -31511,6 +32288,7 @@ YL
 Fg
 Fg
 Fg
+qP
 Fg
 Fg
 Fg
@@ -31518,11 +32296,10 @@ Fg
 Fg
 Fg
 Fg
-Fg
-Fg
+qP
 Fg
 zi
-zi
+aM
 zi
 Wh
 zi
@@ -31586,7 +32363,7 @@ Lb
 Lb
 jv
 Lb
-Lb
+VB
 Lb
 Lb
 VB
@@ -31595,7 +32372,7 @@ Lb
 Lb
 Lb
 yi
-Lb
+VB
 jv
 Lb
 Lb
@@ -31608,7 +32385,7 @@ PS
 PS
 PS
 sx
-Fg
+qP
 Fg
 Fg
 qP
@@ -31630,7 +32407,7 @@ Fg
 gG
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -31686,6 +32463,7 @@ zi
 zi
 zi
 zi
+aM
 zi
 zi
 zi
@@ -31693,8 +32471,7 @@ zi
 zi
 zi
 zi
-zi
-zi
+aM
 zi
 zi
 zi
@@ -31712,7 +32489,7 @@ LZ
 PS
 sl
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -31732,9 +32509,9 @@ Lb
 Lb
 Lb
 Lb
+VB
 Lb
 Lb
-Lb
 PS
 PS
 PS
@@ -31747,7 +32524,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -31770,7 +32547,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 YL
 qP
 Fg
@@ -31779,7 +32556,7 @@ Fg
 Fg
 Fg
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -31856,7 +32633,7 @@ Lb
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 yi
 Lb
@@ -31914,9 +32691,9 @@ Fg
 Fg
 Fg
 Fg
-Fg
-Fg
 qP
+Fg
+Fg
 zi
 zi
 mR
@@ -31928,29 +32705,30 @@ zi
 zi
 zi
 zi
-zi
+aM
 zi
 zi
 aM
 zi
-zi
-zi
-zi
-mR
-mR
-mR
-mR
-mR
-mR
-mR
-mR
-mR
 zi
 aM
 zi
 mR
 mR
 mR
+mR
+mR
+mR
+mR
+mR
+mR
+zi
+aM
+zi
+mR
+mR
+mR
+aM
 zi
 zi
 zi
@@ -31961,8 +32739,7 @@ zi
 zi
 zi
 zi
-zi
-zi
+aM
 mR
 mR
 mR
@@ -31982,7 +32759,7 @@ Lb
 Lb
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb
@@ -32028,7 +32805,7 @@ sx
 sx
 sx
 Fg
-Fg
+qP
 Fg
 Fg
 Fg
@@ -32049,7 +32826,7 @@ Fg
 Fg
 Fg
 Fg
-zi
+aM
 zi
 mR
 BH
@@ -32136,7 +32913,7 @@ PS
 Lb
 Lb
 Fg
-Fg
+qP
 Fg
 sx
 sx
@@ -32219,7 +32996,7 @@ mR
 mR
 mR
 zi
-zi
+aM
 zi
 zi
 aM
@@ -32328,7 +33105,7 @@ mR
 mR
 zi
 zi
-zi
+aM
 zi
 mR
 mR
@@ -32393,7 +33170,7 @@ PS
 PS
 Lb
 Lb
-Lb
+VB
 Lb
 Lb
 Lb

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -3,6 +3,13 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/armoury)
+"ab" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/arrivals)
 "ac" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -51,11 +58,26 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark/blue2,
 /area/outpost/medbay/storage)
+"am" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/dormitories)
 "an" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/research)
+"ao" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 9
+	},
+/area/outpost/caves/south)
 "aq" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2{
@@ -182,11 +204,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
+"aY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/dormitories)
 "ba" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 8
 	},
@@ -200,6 +229,18 @@
 	dir = 5
 	},
 /area/outpost/arrivals)
+"bd" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/outpost/brig)
 "bf" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/writing{
@@ -246,6 +287,10 @@
 	dir = 6
 	},
 /area/outpost/yard/east)
+"bp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2,
+/area/outpost/brig/wardens_office)
 "bq" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/tile/dark,
@@ -309,6 +354,7 @@
 /area/outpost/science)
 "bF" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/cargo)
 "bG" = (
@@ -346,6 +392,10 @@
 "bP" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/central)
+"bQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/west)
 "bR" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -481,6 +531,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
 "cF" = (
@@ -516,8 +567,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering/security)
+"cQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
+/area/outpost/hallway/central)
 "cR" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2
@@ -581,6 +639,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig)
 "dg" = (
@@ -646,6 +705,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/lz1)
 "ds" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2{
 	dir = 6
 	},
@@ -745,6 +805,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/arrivals)
+"dQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/science)
 "dS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -822,6 +888,7 @@
 "el" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/central)
 "em" = (
@@ -868,6 +935,12 @@
 	dir = 8
 	},
 /area/outpost/caves/south)
+"ev" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 6
+	},
+/area/outpost/hallway/east)
 "ew" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
@@ -889,6 +962,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
+"eA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 6
+	},
+/area/outpost/caves/north)
 "eB" = (
 /obj/machinery/prop/autolathe,
 /obj/machinery/light,
@@ -930,6 +1009,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
 "eJ" = (
@@ -1031,6 +1111,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south)
+"fg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/outpost/caves/north)
 "fi" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -1208,6 +1294,14 @@
 	dir = 4
 	},
 /area/outpost/medbay/storage)
+"fT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg2,
+/area/outpost/arrivals)
+"fU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/yard/west)
 "fV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -1226,6 +1320,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -1409,6 +1504,12 @@
 	dir = 5
 	},
 /area/outpost/cargo/engineering)
+"gJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/outpost/engineering/hallway)
 "gK" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1450,6 +1551,10 @@
 	dir = 10
 	},
 /area/outpost/engineering/hallway)
+"gV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/north_west)
 "gW" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -1551,6 +1656,11 @@
 "hs" = (
 /turf/open/floor/plating/dmg1,
 /area/outpost/arrivals)
+"ht" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "hv" = (
 /obj/machinery/light{
 	dir = 1
@@ -1563,6 +1673,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/outpost/science/hydponics)
+"hy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/brig/armoury)
+"hE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/yard/south_east)
 "hF" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -1625,6 +1743,12 @@
 	dir = 1
 	},
 /area/outpost/medbay/chemistry)
+"hQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/yard/south_east)
 "hR" = (
 /obj/machinery/landinglight/lz1{
 	dir = 4
@@ -1633,6 +1757,12 @@
 	dir = 4
 	},
 /area/outpost/lz1)
+"hU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/dormitories)
 "hV" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
@@ -1850,6 +1980,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/hallway/south_west)
+"iO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
+/area/outpost/caves/north_west)
 "iQ" = (
 /obj/effect/landmark/corpsespawner/engineer{
 	corpseback = /obj/item/storage/backpack;
@@ -1985,6 +2121,10 @@
 	dir = 4
 	},
 /area/outpost/engineering)
+"jv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/hallway/east)
 "jw" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/purple2{
@@ -1997,6 +2137,12 @@
 	dir = 4
 	},
 /area/outpost/cargo)
+"jz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/yard/east)
 "jA" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/yellow2{
@@ -2022,6 +2168,7 @@
 	dir = 8
 	},
 /obj/item/trash/barcardine,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/outpost/dormitories)
 "jE" = (
@@ -2069,6 +2216,11 @@
 	dir = 8
 	},
 /area/outpost/yard/east)
+"jN" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/hallway/south_west)
 "jO" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -2190,6 +2342,12 @@
 	dir = 4
 	},
 /area/outpost/medbay)
+"km" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/cargo)
 "kn" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
@@ -2204,6 +2362,10 @@
 	dir = 5
 	},
 /area/outpost/science/hydponics)
+"kp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/west)
 "kq" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/tramadol,
@@ -2248,12 +2410,27 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz1)
+"kC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/outpost/dormitories)
+"kD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 10
+	},
+/area/outpost/cargo)
 "kE" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/outpost/dormitories)
+"kG" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2,
+/area/outpost/brig)
 "kH" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
@@ -2279,8 +2456,13 @@
 "kL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science)
+"kM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/arrivals)
 "kN" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south)
@@ -2441,6 +2623,7 @@
 	dir = 10
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
@@ -2583,6 +2766,12 @@
 	dir = 8
 	},
 /area/outpost/science/xenobiology)
+"lW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/outpost/yard/central)
 "lX" = (
 /obj/structure/bed/chair/office{
 	dir = 4
@@ -2623,6 +2812,12 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/outpost/lz1)
+"mf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/east)
 "mg" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -2641,10 +2836,19 @@
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science)
 "mj" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
 	},
 /area/outpost/science)
+"mm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/central)
+"mn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo/engineering)
 "mp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -2690,6 +2894,12 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"mC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/south)
 "mF" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/decal/cleanable/blood/writing{
@@ -2717,6 +2927,7 @@
 /area/outpost/hallway/central)
 "mL" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/central)
 "mM" = (
@@ -2751,6 +2962,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south)
+"mU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/south_east)
 "mV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -2793,6 +3010,7 @@
 /area/outpost/science/xenobiology)
 "nh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -2901,6 +3119,7 @@
 	},
 /area/outpost/cargo/engineering)
 "nB" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/dmg2,
 /area/outpost/hallway/south_east)
 "nC" = (
@@ -2926,6 +3145,22 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
 /area/outpost/medbay)
+"nH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/north)
+"nJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
+/area/outpost/brig/gear_room)
+"nK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/hallway/northern)
 "nL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2963,6 +3198,7 @@
 	},
 /area/outpost/engineering)
 "nR" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
@@ -3004,6 +3240,10 @@
 	dir = 8
 	},
 /area/outpost/medbay/storage)
+"nZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/south)
 "oa" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -3328,6 +3568,12 @@
 "py" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/yard/east)
+"pz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/yard/central)
 "pA" = (
 /obj/machinery/light{
 	dir = 4
@@ -3360,6 +3606,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/hallway/west)
+"pE" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/medbay/storage)
 "pF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -3407,6 +3660,10 @@
 	dir = 1
 	},
 /area/outpost/medbay/chemistry)
+"pM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/west)
 "pN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3491,6 +3748,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_west)
 "qh" = (
@@ -3594,6 +3852,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
@@ -3658,6 +3917,10 @@
 	dir = 4
 	},
 /area/outpost/engineering/hallway)
+"qU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random,
+/area/outpost/caves/north_west)
 "qV" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -3844,6 +4107,7 @@
 	},
 /area/outpost/hallway/south_east)
 "rF" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
@@ -3892,6 +4156,10 @@
 	dir = 6
 	},
 /area/outpost/dormitories)
+"rQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/brig/gear_room)
 "rR" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/writing{
@@ -3899,6 +4167,12 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
+"rS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/outpost/yard/central)
 "rU" = (
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
@@ -4157,6 +4431,14 @@
 	dir = 4
 	},
 /area/outpost/hallway/northern)
+"tc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/south_east)
 "td" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/tile/dark,
@@ -4216,10 +4498,21 @@
 	dir = 9
 	},
 /area/outpost/caves/north_east)
+"tq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/outpost/yard/central)
 "tr" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/chemistry)
+"ts" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/arrivals)
 "tt" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -4241,6 +4534,10 @@
 	dir = 4
 	},
 /area/outpost/hallway/northern)
+"tw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/outpost/dormitories)
 "tx" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2,
@@ -4306,6 +4603,10 @@
 	dir = 8
 	},
 /area/outpost/hallway/west)
+"tN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/engineering)
 "tO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4392,6 +4693,12 @@
 	dir = 1
 	},
 /area/outpost/yard/south)
+"ul" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/west)
 "un" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/red2,
@@ -4404,6 +4711,11 @@
 	dir = 1
 	},
 /area/outpost/lz1)
+"uq" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/outpost/engineering/engine)
 "ur" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/marking/asteroidwarning{
@@ -4461,6 +4773,15 @@
 	dir = 8
 	},
 /area/outpost/hallway/northern)
+"uF" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 4
+	},
+/area/outpost/dormitories)
 "uG" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
@@ -4574,6 +4895,10 @@
 	dir = 8
 	},
 /area/outpost/cargo)
+"vl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/west)
 "vm" = (
 /obj/structure/prop/mainship/research/destructive_analyzer,
 /turf/open/floor/tile/dark/purple2{
@@ -4617,8 +4942,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/armoury)
+"vu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/north)
 "vx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4700,6 +5030,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/science/research)
+"vL" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/central)
 "vO" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -4729,6 +5064,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/cavetodirt,
 /area/outpost/caves/north_east)
+"vT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/medbay/storage)
 "vU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4894,6 +5233,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_west)
+"wF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 10
+	},
+/area/outpost/caves/south)
 "wG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4924,6 +5269,7 @@
 /area/outpost/caves/south)
 "wN" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 10
 	},
@@ -5083,6 +5429,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/central)
 "xu" = (
@@ -5119,6 +5466,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals/securitylz1)
 "xD" = (
@@ -5135,6 +5483,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
+"xM" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/hallway/south_west)
 "xO" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -5173,10 +5528,19 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/blue2/corner{
 	dir = 8
 	},
 /area/outpost/medbay)
+"xY" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/outpost/engineering/engine)
 "xZ" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/tile/dark/brown2{
@@ -5291,6 +5655,10 @@
 "ys" = (
 /turf/closed/wall/r_wall,
 /area/outpost/cargo/engineering)
+"yt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/central)
 "yu" = (
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/tile/dark2,
@@ -5374,8 +5742,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/arrivals)
+"yM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/hallway/west)
 "yN" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
@@ -5393,6 +5766,10 @@
 	dir = 1
 	},
 /area/outpost/arrivals)
+"yQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/east)
 "yS" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -5433,6 +5810,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/central)
+"zb" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/purple2{
+	dir = 8
+	},
+/area/outpost/science/hydponics)
 "zd" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -5488,6 +5872,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/west)
 "zl" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/outpost/yard/north_east)
 "zm" = (
@@ -5610,11 +5995,22 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark2,
 /area/outpost/arrivals/securitylz2)
+"zR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north_west)
 "zT" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/technology_scanner,
 /turf/open/floor/tile/dark,
 /area/outpost/science/xenobiology)
+"zU" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 8
+	},
+/area/outpost/engineering/hallway)
 "zW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -5739,6 +6135,10 @@
 	dir = 4
 	},
 /area/outpost/hallway/central)
+"Ax" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/south)
 "Ay" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /turf/open/floor/marking/asteroidwarning{
@@ -5776,6 +6176,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/west)
 "AH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 10
 	},
@@ -5820,6 +6221,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
 /area/outpost/science/xenobiology)
+"AT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/caves/south)
 "AW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6004,6 +6411,12 @@
 "BJ" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/south_east)
+"BK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/caves/north_west)
 "BL" = (
 /obj/structure/table,
 /obj/effect/spawner/random/weaponry/ammo/shotgun,
@@ -6053,6 +6466,7 @@
 	},
 /area/outpost/science/xenobiology)
 "BY" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
@@ -6152,6 +6566,7 @@
 /area/outpost/hallway/central)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/blue2/corner,
 /area/outpost/medbay/surgery)
 "Cy" = (
@@ -6289,6 +6704,10 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/lz1)
+"Do" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/central)
 "Dp" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/decal/cleanable/blood/writing,
@@ -6330,6 +6749,7 @@
 /turf/open/floor/freezer,
 /area/outpost/dormitories)
 "Dy" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 5
 	},
@@ -6439,6 +6859,7 @@
 /area/outpost/medbay/chemistry)
 "DV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/blue2/corner{
 	dir = 1
 	},
@@ -6452,6 +6873,12 @@
 "DX" = (
 /turf/closed/wall/r_wall,
 /area/outpost/engineering/engine)
+"DZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/east)
 "Ec" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/tile/dark,
@@ -6532,6 +6959,12 @@
 	},
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
+"Er" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/outpost/yard/south_east)
 "Es" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6627,6 +7060,12 @@
 	dir = 4
 	},
 /area/outpost/cargo/office)
+"EN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/north)
 "EP" = (
 /obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/tile/dark/brown2{
@@ -6865,6 +7304,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz1)
+"FP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/purple2{
+	dir = 8
+	},
+/area/outpost/science)
 "FQ" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -6876,6 +7325,12 @@
 	dir = 8
 	},
 /area/outpost/science/hydponics)
+"FS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/purple2{
+	dir = 1
+	},
+/area/outpost/science)
 "FT" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/cavetodirt{
@@ -6903,6 +7358,12 @@
 	dir = 9
 	},
 /area/outpost/yard/west)
+"Gc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 9
+	},
+/area/outpost/caves/north_west)
 "Ge" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 8
@@ -6998,6 +7459,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/trash/cheesie,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
 "GB" = (
@@ -7154,8 +7616,13 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
+"Hu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/outpost/yard/south)
 "Hw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/chemistry)
 "Hx" = (
@@ -7248,9 +7715,20 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/smooth/bigred,
 /area/outpost/lz1)
+"HO" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2,
+/area/outpost/brig)
 "HP" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south_east)
+"HQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/north_east)
 "HR" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/outpost/yard/east)
@@ -7288,11 +7766,23 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/east)
+"Ib" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "Ic" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
+"Id" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/outpost/dormitories)
 "If" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
@@ -7320,14 +7810,13 @@
 	dir = 9
 	},
 /area/outpost/engineering)
+"Io" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/north_east)
 "Ip" = (
 /turf/closed/wall/r_wall,
 /area/outpost/hallway/south_cent)
-"Iq" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
 "Ir" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/dark/brown2{
@@ -7434,6 +7923,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz2)
+"IO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/arrivals)
 "IS" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/paperbin,
@@ -7455,6 +7948,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -7666,6 +8160,15 @@
 	dir = 4
 	},
 /area/outpost/cargo)
+"JW" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 9
+	},
+/area/outpost/brig)
 "JY" = (
 /obj/structure/table,
 /obj/item/trash/cigbutt/cigarbutt,
@@ -7796,6 +8299,10 @@
 	dir = 1
 	},
 /area/outpost/engineering/hallway)
+"Kz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/outpost/engineering/engine)
 "KA" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
@@ -7856,6 +8363,15 @@
 	dir = 10
 	},
 /area/outpost/hallway/central)
+"KK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/cargo)
 "KL" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -8027,6 +8543,12 @@
 "LC" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/cargo)
+"LD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/cargo)
 "LE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -8054,6 +8576,13 @@
 "LJ" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/north)
+"LL" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/blue2{
+	dir = 4
+	},
+/area/outpost/medbay)
 "LM" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 8
@@ -8073,6 +8602,13 @@
 	dir = 5
 	},
 /area/outpost/hallway/northern)
+"LP" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/hallway/south_west)
 "LQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /obj/structure/cable,
@@ -8087,6 +8623,10 @@
 	dir = 5
 	},
 /area/outpost/caves/south)
+"LU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/east)
 "LV" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -8283,6 +8823,12 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"MI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 10
+	},
+/area/outpost/caves/north_east)
 "MJ" = (
 /obj/machinery/botany/extractor,
 /turf/open/floor/tile/dark/purple2{
@@ -8339,6 +8885,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/trash/sosjerky,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
@@ -8354,6 +8901,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/gear_room)
 "Na" = (
@@ -8376,6 +8924,10 @@
 	dir = 8
 	},
 /area/outpost/arrivals/securitylz1)
+"Ng" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/cargo)
 "Nh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -8386,10 +8938,19 @@
 /area/outpost/hallway/central)
 "Nj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
 /area/outpost/engineering/engine)
+"Nk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/science/hydponics)
+"Nl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/north)
 "Nm" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -8545,6 +9106,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/security)
 "NV" = (
@@ -8553,6 +9115,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals)
+"NW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/yellow2,
+/area/outpost/engineering/hallway)
 "NX" = (
 /turf/closed/wall/r_wall,
 /area/outpost/cargo/security)
@@ -8573,6 +9143,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 9
 	},
@@ -8585,6 +9156,7 @@
 "Oe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 6
 	},
@@ -8729,6 +9301,10 @@
 "OH" = (
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/arrivals)
+"OI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/cargo)
 "OK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -8767,9 +9343,19 @@
 "OR" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/north)
+"OS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "OT" = (
 /turf/closed/mineral/smooth/bigred,
 /area/outpost/yard/east)
+"OU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 5
+	},
+/area/outpost/brig)
 "OV" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -8807,6 +9393,14 @@
 	dir = 1
 	},
 /area/outpost/science/hydponics)
+"Pf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/central)
+"Pg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/medbay)
 "Pi" = (
 /obj/machinery/prop/computer/rdconsole,
 /turf/open/floor/tile/dark/purple2{
@@ -8878,6 +9472,10 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"Pw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/north_east)
 "Px" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -9154,6 +9752,7 @@
 	dir = 4
 	},
 /obj/item/attachable/reddot,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/northern)
 "QH" = (
@@ -9174,15 +9773,35 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/south_west)
+"QL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/south)
 "QN" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
 /area/outpost/arrivals)
+"QO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north)
 "QP" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north)
+"QQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/dormitories)
 "QW" = (
 /obj/machinery/landinglight/lz2{
 	dir = 4
@@ -9191,6 +9810,12 @@
 	dir = 8
 	},
 /area/outpost/lz2)
+"QX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/outpost/hallway/west)
 "QY" = (
 /turf/closed/wall/r_wall,
 /area/outpost/cargo)
@@ -9245,6 +9870,7 @@
 "Ri" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/central)
 "Rk" = (
@@ -9330,6 +9956,14 @@
 	dir = 8
 	},
 /area/outpost/science)
+"Rw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/engineering)
 "Rx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -9435,6 +10069,10 @@
 	dir = 8
 	},
 /area/outpost/hallway/south_west)
+"RU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/purple2,
+/area/outpost/science/xenobiology)
 "RV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -9445,6 +10083,11 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/arrivals)
+"RY" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_west)
 "RZ" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -9461,6 +10104,10 @@
 	dir = 5
 	},
 /area/outpost/arrivals/securitylz1)
+"Sd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/east)
 "Se" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -9571,6 +10218,24 @@
 "SB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/west)
+"SE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/outpost/caves/west)
+"SF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/outpost/caves/south)
+"SH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 8
+	},
+/area/outpost/arrivals/securitylz2)
 "SJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -9694,6 +10359,12 @@
 /obj/item/clothing/shoes/galoshes,
 /turf/open/floor/wood,
 /area/outpost/dormitories)
+"Tm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/central)
 "To" = (
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
@@ -9702,6 +10373,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
 "Tq" = (
@@ -9718,6 +10390,16 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/cargo)
+"Ts" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/hallway/south_east)
+"Tt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/outpost/caves/north_west)
 "Tv" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 9
@@ -9969,6 +10651,12 @@
 	dir = 5
 	},
 /area/outpost/medbay/chemistry)
+"Uz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/yard/east)
 "UB" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -10125,6 +10813,11 @@
 "Vj" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/lz1)
+"Vk" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "Vl" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -10209,6 +10902,20 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"VF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/arrivals/securitylz2)
+"VG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/east)
 "VH" = (
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/tile/dark/yellow2{
@@ -10255,6 +10962,7 @@
 /area/outpost/lz1)
 "VT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/hallway/central)
 "VU" = (
@@ -10379,6 +11087,10 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
+"Wv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/south_east)
 "Ww" = (
 /obj/machinery/prop/computer/rdservercontrol,
 /turf/open/floor/tile/dark/purple2,
@@ -10408,6 +11120,10 @@
 	dir = 10
 	},
 /area/outpost/hallway/central)
+"WB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/south)
 "WE" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
@@ -10489,6 +11205,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/northern)
 "Xb" = (
@@ -10525,6 +11242,11 @@
 	dir = 8
 	},
 /area/outpost/hallway/central)
+"Xi" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "Xj" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -10550,6 +11272,15 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/caves/west)
+"Xo" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/outpost/brig)
 "Xp" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -10586,6 +11317,7 @@
 "Xx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 6
 	},
@@ -10726,6 +11458,12 @@
 	dir = 5
 	},
 /area/outpost/cargo/engineering)
+"Yb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/outpost/yard/central)
 "Yc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -10797,6 +11535,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south_east)
+"Yu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/east)
 "Yv" = (
 /obj/machinery/light{
 	dir = 1
@@ -10892,6 +11636,12 @@
 	dir = 4
 	},
 /area/outpost/yard/central)
+"YO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/yard/central)
 "YQ" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/writing{
@@ -10905,6 +11655,12 @@
 	dir = 6
 	},
 /area/outpost/yard/central)
+"YT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/south)
 "YU" = (
 /turf/closed/wall,
 /area/outpost/medbay/chemistry)
@@ -10936,6 +11692,7 @@
 	},
 /area/outpost/hallway/west)
 "Ze" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/blue2{
 	dir = 4
 	},
@@ -10982,6 +11739,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/science/rd_office)
+"Zo" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/central)
 "Zp" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
@@ -11016,6 +11778,7 @@
 /area/outpost/engineering/security)
 "Zu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/hallway/south_cent)
 "Zv" = (
@@ -12547,7 +13310,7 @@ EB
 EB
 EB
 EB
-EB
+bQ
 Nu
 zh
 zh
@@ -12675,7 +13438,7 @@ zh
 nR
 XX
 XX
-XX
+vl
 Cs
 yW
 yW
@@ -12720,7 +13483,7 @@ vp
 yW
 ho
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -12786,7 +13549,7 @@ AL
 AL
 dn
 EB
-EB
+bQ
 VV
 zh
 zh
@@ -12903,7 +13666,7 @@ yW
 yW
 yW
 cB
-cB
+BK
 cB
 IU
 IU
@@ -12917,7 +13680,7 @@ Pt
 Pt
 Pt
 Pt
-XX
+vl
 XX
 yW
 yW
@@ -13205,7 +13968,7 @@ yW
 yW
 ho
 ho
-ho
+Uu
 yW
 yW
 yW
@@ -13270,7 +14033,7 @@ FZ
 uK
 IU
 yP
-yh
+ab
 Ef
 Og
 Tq
@@ -13387,7 +14150,7 @@ yW
 yW
 FZ
 FZ
-uK
+Gc
 Cp
 IU
 Oc
@@ -13523,7 +14286,7 @@ NO
 NO
 Pt
 Rr
-Rr
+SE
 Rr
 Rr
 yW
@@ -13627,7 +14390,7 @@ ZX
 Cp
 Xc
 FZ
-FZ
+zR
 FZ
 xU
 Cp
@@ -13646,7 +14409,7 @@ IU
 EB
 EB
 EB
-EB
+bQ
 EB
 EB
 yW
@@ -13690,7 +14453,7 @@ ho
 ho
 ho
 ho
-ho
+Uu
 ja
 yW
 gw
@@ -13735,7 +14498,7 @@ Cp
 Zj
 Cp
 Cp
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -13752,7 +14515,7 @@ FZ
 uK
 Cp
 Cp
-dw
+fT
 rJ
 yh
 NJ
@@ -13807,7 +14570,7 @@ Hc
 VS
 AW
 wE
-ho
+Uu
 ho
 ho
 ho
@@ -13870,7 +14633,7 @@ yW
 yW
 yW
 yW
-Cp
+ZX
 GI
 Cp
 dw
@@ -13879,10 +14642,10 @@ yh
 IS
 Og
 VC
+uG
 Vt
 Vt
-Vt
-Vt
+uG
 OH
 Vt
 Zl
@@ -13969,13 +14732,13 @@ yW
 yW
 yW
 ja
+ZX
 Cp
 Cp
 Cp
-Cp
-Cp
+ZX
 Zj
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -13996,21 +14759,21 @@ Cp
 Cp
 IU
 hv
-yh
+ab
 DP
 Og
 VC
 Vt
 Vt
 Vt
-uG
+Vt
 OH
 IU
 yL
 Zl
 Zl
 Zl
-Zl
+kM
 dP
 Zl
 RW
@@ -14050,7 +14813,7 @@ VS
 AW
 wE
 ho
-Uu
+ho
 ho
 ux
 ho
@@ -14100,7 +14863,7 @@ Cp
 Cp
 yW
 Cp
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -14173,7 +14936,7 @@ ja
 ho
 ho
 ho
-Uu
+ho
 ho
 ja
 yW
@@ -14213,7 +14976,7 @@ yW
 ja
 Cp
 Cp
-Cp
+ZX
 Cp
 Cp
 ja
@@ -14235,18 +14998,18 @@ yW
 yW
 yW
 Cp
-sB
+iO
 IU
 NA
 Vt
 IS
 Og
 gv
-wK
+ts
 wK
 wK
 NV
-OH
+IO
 Vt
 wU
 wU
@@ -14295,7 +15058,7 @@ yW
 ho
 ho
 ho
-ho
+Uu
 ja
 yW
 gw
@@ -14330,7 +15093,7 @@ yW
 yW
 yW
 yW
-Cp
+ZX
 Zj
 Zj
 Zj
@@ -14371,9 +15134,9 @@ Rn
 IU
 Jb
 Jb
+pM
 Jb
-Jb
-Jb
+pM
 Jb
 yW
 Cc
@@ -14465,7 +15228,7 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 Cp
 yW
@@ -14657,7 +15420,7 @@ yW
 yW
 ho
 ho
-ho
+Uu
 ho
 yW
 yW
@@ -14696,7 +15459,7 @@ yW
 Cp
 YH
 Cp
-Cp
+ZX
 Cp
 Cp
 yW
@@ -14722,11 +15485,11 @@ FZ
 FZ
 Ev
 Hh
-Hh
+qU
 Hh
 fz
 LI
-SB
+yM
 lf
 cc
 cc
@@ -14814,7 +15577,7 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -14824,15 +15587,15 @@ yW
 yW
 vW
 FZ
-FZ
+zR
 FZ
 yW
 yW
 yW
 FZ
+zR
 FZ
-FZ
-FZ
+zR
 TK
 sB
 IL
@@ -14840,7 +15603,7 @@ Cp
 Xc
 FZ
 TW
-rn
+Tt
 Hh
 Hh
 Hh
@@ -14851,11 +15614,11 @@ gc
 lf
 cc
 cc
+kp
 cc
 cc
 cc
-cc
-cc
+kp
 cc
 yW
 yW
@@ -14898,7 +15661,7 @@ vp
 yW
 yW
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -14941,7 +15704,7 @@ Cp
 Cp
 Cp
 Cp
-Cp
+ZX
 Cp
 YH
 DG
@@ -14957,7 +15720,7 @@ FZ
 FZ
 FZ
 FT
-Cp
+ZX
 Xc
 FZ
 FZ
@@ -15177,7 +15940,7 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 yW
 yW
@@ -15206,7 +15969,7 @@ do
 xj
 kX
 oe
-Ah
+QX
 lZ
 lZ
 Fh
@@ -15305,7 +16068,7 @@ yW
 yW
 yW
 Cp
-sB
+iO
 sB
 yW
 yW
@@ -15381,7 +16144,7 @@ yW
 vp
 ho
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -15444,7 +16207,7 @@ US
 Iz
 kc
 VE
-To
+Pg
 Dt
 nx
 To
@@ -15461,7 +16224,7 @@ yW
 yW
 cc
 cc
-KZ
+fU
 KZ
 yW
 yW
@@ -15541,7 +16304,7 @@ yW
 yW
 Cp
 Cp
-Cp
+ZX
 yW
 yW
 yW
@@ -15554,7 +16317,7 @@ yW
 bY
 it
 UL
-UL
+vT
 Rd
 bq
 fa
@@ -15690,7 +16453,7 @@ mV
 To
 hM
 oe
-QH
+ul
 kb
 oI
 yW
@@ -15826,7 +16589,7 @@ Wa
 ai
 ai
 ai
-ai
+Pf
 YR
 yW
 yW
@@ -15844,7 +16607,7 @@ WV
 yJ
 tl
 LC
-LC
+Ng
 kx
 kx
 kx
@@ -15852,9 +16615,9 @@ kx
 kx
 LC
 LC
+Ng
 LC
-LC
-LC
+Ng
 LC
 kx
 kx
@@ -15904,7 +16667,7 @@ yW
 yW
 yW
 yW
-YH
+RY
 Cp
 Cp
 Cp
@@ -15944,7 +16707,7 @@ yW
 ai
 ij
 ij
-ij
+Yb
 ij
 ij
 YR
@@ -15959,7 +16722,7 @@ QY
 QY
 QY
 QY
-gW
+LD
 WV
 WV
 bF
@@ -15985,7 +16748,7 @@ yW
 yW
 yW
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -16029,15 +16792,15 @@ Cp
 Cp
 Cp
 Cp
-Cp
+ZX
 Cp
 Xc
 rn
 AL
-AL
+gV
 bY
 Ru
-nv
+pE
 UL
 cV
 bq
@@ -16046,7 +16809,7 @@ Zw
 Rf
 TR
 Us
-To
+Pg
 To
 jS
 sw
@@ -16086,17 +16849,17 @@ lS
 JH
 lS
 TE
+km
 lS
 lS
-lS
-lS
+km
 TE
 GE
 yz
 GE
 GE
 TE
-lS
+km
 lS
 tY
 QY
@@ -16181,6 +16944,7 @@ FA
 SB
 oI
 EA
+yt
 EA
 EA
 EA
@@ -16189,8 +16953,7 @@ EA
 EA
 EA
 EA
-EA
-EA
+yt
 EA
 EA
 Xl
@@ -16219,7 +16982,7 @@ VI
 xD
 vD
 bg
-oy
+OI
 QY
 yW
 yW
@@ -16274,7 +17037,7 @@ yW
 yW
 yW
 yW
-FZ
+zR
 rn
 AL
 bY
@@ -16298,7 +17061,7 @@ Nz
 sz
 eX
 ig
-FA
+qV
 aA
 oI
 EA
@@ -16314,7 +17077,7 @@ EA
 EA
 EA
 EA
-Xl
+rS
 yW
 yW
 yW
@@ -16325,7 +17088,7 @@ hZ
 Jc
 Jc
 Jc
-pw
+ht
 Jc
 pf
 jx
@@ -16337,7 +17100,7 @@ Jc
 zC
 jx
 SU
-Jc
+OS
 zC
 Yi
 oy
@@ -16424,9 +17187,9 @@ SB
 fz
 QE
 QE
+QE
+QE
 Ui
-QE
-QE
 QE
 QE
 AH
@@ -16442,7 +17205,7 @@ yW
 QY
 IG
 Jc
-Jc
+OS
 Jc
 Jc
 Jz
@@ -16469,7 +17232,7 @@ yW
 yW
 ho
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -16530,7 +17293,7 @@ Ux
 Cl
 Ys
 To
-To
+Pg
 To
 nx
 ly
@@ -16555,7 +17318,7 @@ EA
 EA
 EA
 EA
-EA
+yt
 EA
 EA
 yW
@@ -16571,7 +17334,7 @@ pw
 Xj
 CF
 rK
-tY
+kD
 Jc
 jY
 tY
@@ -16639,11 +17402,11 @@ yW
 OR
 OR
 QZ
-IY
+nH
 ZP
 jR
 to
-HW
+LL
 HW
 Qe
 Iv
@@ -16688,7 +17451,7 @@ Pq
 Jc
 Jc
 yu
-pw
+ht
 Xj
 zC
 jx
@@ -16696,14 +17459,14 @@ Aa
 Jc
 og
 EP
-Jc
+OS
 Tw
 jx
 Yi
 Jc
 pf
 AK
-oy
+OI
 QY
 yW
 yW
@@ -16787,13 +17550,13 @@ SB
 oI
 yW
 cU
-cU
+pz
 ae
 EA
 EA
 FH
 sY
-EA
+yt
 EA
 EA
 EA
@@ -16811,7 +17574,7 @@ Jc
 Jz
 uW
 DN
-LY
+Ib
 LY
 LY
 LY
@@ -16821,7 +17584,7 @@ kf
 Jc
 Jc
 Jc
-Jc
+OS
 Jc
 Mt
 Tr
@@ -16878,7 +17641,7 @@ yW
 yW
 uU
 uU
-uU
+Su
 UN
 OR
 yW
@@ -16921,12 +17684,12 @@ QE
 QE
 QE
 QE
-QE
+Ui
 QE
 pa
 IG
 Jc
-Jc
+OS
 Jc
 Mt
 Jc
@@ -16948,7 +17711,7 @@ VI
 oy
 QY
 hK
-hK
+IH
 hK
 hK
 hK
@@ -17021,7 +17784,7 @@ yW
 yW
 yW
 oI
-QH
+ul
 zk
 oI
 oI
@@ -17052,31 +17815,31 @@ Jc
 pw
 pw
 Xs
-Jc
+OS
 pf
 Qj
 AK
-Jc
+OS
 Tw
 OL
-Jc
+OS
 zC
 Qj
 Zk
 Jc
 IA
 oV
-oy
+OI
 QY
 hK
 hK
 hK
 hK
+IH
 hK
 hK
 hK
-hK
-hK
+IH
 hK
 yW
 yW
@@ -17119,7 +17882,7 @@ yW
 Az
 iH
 uU
-Su
+uU
 uU
 yW
 yW
@@ -17156,7 +17919,7 @@ EA
 EA
 EA
 EA
-EA
+yt
 EA
 EA
 EA
@@ -17184,7 +17947,7 @@ JV
 JV
 JV
 JV
-fC
+KK
 JV
 JV
 SU
@@ -17311,7 +18074,7 @@ QY
 QY
 QY
 hK
-hK
+IH
 hK
 hK
 hK
@@ -17356,7 +18119,7 @@ ja
 yW
 yW
 yW
-Iq
+fV
 uU
 wk
 Su
@@ -17438,7 +18201,7 @@ yW
 yW
 hK
 hK
-hK
+IH
 hK
 yW
 yW
@@ -17477,7 +18240,7 @@ ja
 yW
 yW
 yW
-uU
+Su
 uU
 wk
 yW
@@ -17503,12 +18266,12 @@ yW
 ww
 ww
 LH
-TY
+cQ
 yU
 Ap
 HJ
 PU
-yU
+vL
 Sb
 KH
 ww
@@ -17522,11 +18285,11 @@ yW
 yW
 yW
 ai
-RD
+tq
 bG
 EA
 FH
-sY
+UO
 cU
 ku
 xZ
@@ -17548,7 +18311,7 @@ Nx
 Cy
 Hf
 Mr
-wM
+mC
 mS
 EF
 EF
@@ -17636,7 +18399,7 @@ ns
 ww
 ww
 yW
-ai
+Pf
 ai
 yW
 yW
@@ -17666,7 +18429,7 @@ yW
 yW
 yW
 tm
-tm
+AT
 Mr
 Mr
 yW
@@ -17719,7 +18482,7 @@ ja
 yW
 uU
 pZ
-Su
+uU
 yW
 ja
 yW
@@ -17728,7 +18491,7 @@ uU
 uU
 uU
 uU
-Vh
+eA
 OR
 OR
 yW
@@ -17798,7 +18561,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 yW
 ja
@@ -17919,7 +18682,7 @@ IH
 hK
 hK
 hK
-IH
+hK
 hK
 hK
 ja
@@ -17999,7 +18762,7 @@ xt
 GM
 qQ
 OA
-vH
+xM
 nk
 vH
 Kc
@@ -18093,17 +18856,17 @@ uU
 yW
 OR
 OR
-OR
+QO
 QZ
 IY
-IY
+nH
 Mv
 Dg
 ix
 ol
 tv
 wG
-tv
+nK
 rf
 PU
 TO
@@ -18137,7 +18900,7 @@ xl
 MV
 xl
 Pu
-xl
+dx
 MV
 xl
 Xx
@@ -18148,7 +18911,7 @@ Mr
 mg
 wM
 hK
-hK
+IH
 hK
 hK
 yW
@@ -18250,7 +19013,7 @@ Ke
 Ke
 Ke
 aP
-Yn
+jN
 Ke
 pe
 pe
@@ -18266,7 +19029,7 @@ Ip
 yW
 yW
 Mr
-Mr
+nZ
 Wm
 hK
 hK
@@ -18280,8 +19043,8 @@ yW
 yW
 yW
 hK
-hK
 IH
+hK
 hK
 hK
 hK
@@ -18483,21 +19246,21 @@ jK
 ww
 ww
 ai
-ai
+Pf
 pe
 dN
 cy
 cy
 Wb
-zD
+LP
 zD
 zD
 Ki
 pe
-wa
+Ax
 uJ
 kn
-jF
+YT
 kN
 Mb
 mN
@@ -18595,7 +19358,7 @@ ww
 Me
 TF
 PU
-PU
+Do
 mK
 PU
 oR
@@ -18621,7 +19384,7 @@ wj
 kN
 Np
 rA
-mN
+WB
 BQ
 Yk
 ic
@@ -18632,7 +19395,7 @@ yW
 yW
 yW
 Mr
-wM
+mC
 hK
 hK
 yW
@@ -18692,7 +19455,7 @@ yW
 yW
 yW
 uU
-uU
+Su
 Vh
 OR
 yW
@@ -18842,20 +19605,20 @@ mK
 iR
 ww
 ww
-EA
+yt
 Ei
 Fc
 Fc
 Fc
 Fc
-Fc
+By
 Fc
 On
 aP
 Yn
 On
 jF
-jF
+YT
 jF
 jF
 jF
@@ -18884,10 +19647,10 @@ yW
 yW
 hK
 hK
+IH
 hK
 hK
-hK
-hK
+IH
 yW
 yW
 yW
@@ -18981,7 +19744,7 @@ Np
 Np
 Np
 Hs
-Mb
+Hu
 mN
 ES
 yW
@@ -18990,13 +19753,13 @@ Ip
 Ip
 qc
 YI
-mZ
+cK
 Ip
 yW
 yW
 yW
 hK
-hK
+IH
 hK
 yW
 yW
@@ -19058,7 +19821,7 @@ yW
 yW
 yW
 XD
-uU
+Su
 uU
 uU
 yW
@@ -19114,7 +19877,7 @@ kQ
 MB
 Ip
 Cy
-Cy
+QL
 yW
 yW
 wy
@@ -19124,7 +19887,7 @@ yW
 yW
 wQ
 hK
-hK
+IH
 hK
 wQ
 yW
@@ -19184,7 +19947,7 @@ uU
 uU
 yW
 OW
-bR
+fg
 IY
 oJ
 ML
@@ -19198,16 +19961,16 @@ yW
 yW
 yW
 yW
-LJ
+Nl
 LJ
 aN
 Sq
-Gy
+jv
 Oh
 EA
 EA
 oM
-CY
+mm
 EA
 fG
 fG
@@ -19302,7 +20065,7 @@ yW
 yW
 uU
 uU
-uU
+Su
 Co
 OR
 OR
@@ -19314,7 +20077,7 @@ uD
 ZJ
 tt
 Kq
-Uw
+EN
 fI
 yW
 yW
@@ -19460,13 +20223,13 @@ dY
 Eu
 fG
 ZK
-ZK
+kC
 ZK
 fG
 mN
 Zg
 Mb
-mN
+WB
 yW
 yW
 yW
@@ -19477,7 +20240,7 @@ kQ
 ii
 Ip
 Cy
-Cy
+QL
 Cy
 my
 Mr
@@ -19571,7 +20334,7 @@ Of
 Of
 bP
 in
-EA
+yt
 fG
 QI
 HT
@@ -19584,7 +20347,7 @@ fs
 ZK
 Iy
 fG
-mN
+WB
 wj
 Mb
 mN
@@ -19601,7 +20364,7 @@ yW
 tm
 tm
 Mr
-Mr
+nZ
 wM
 hK
 hK
@@ -19666,7 +20429,7 @@ XD
 uU
 uU
 uU
-uU
+Su
 yW
 yW
 yW
@@ -19678,14 +20441,14 @@ Zz
 fQ
 vV
 LJ
-LJ
+Nl
 pQ
 Qh
-LJ
+Nl
 LJ
 LJ
 aN
-jG
+VG
 Gy
 aN
 EA
@@ -19698,7 +20461,7 @@ fG
 MC
 fG
 fG
-Fu
+am
 aG
 fG
 fG
@@ -19784,7 +20547,7 @@ yW
 yW
 hL
 uU
-uU
+Su
 uU
 uU
 yW
@@ -19831,7 +20594,7 @@ Hs
 Mb
 mN
 ES
-wa
+Ax
 Ip
 kJ
 Ab
@@ -19902,7 +20665,7 @@ yW
 yW
 yW
 yW
-uU
+Su
 HU
 uU
 uU
@@ -19922,7 +20685,7 @@ vV
 LJ
 LJ
 pQ
-xd
+Qh
 LJ
 Ra
 ED
@@ -19933,18 +20696,18 @@ aN
 yW
 EA
 UC
-Of
+YO
 Of
 tK
 ZD
-ki
+hU
 ki
 ki
 Gf
 bz
 ki
 ki
-ki
+hU
 rP
 tK
 Np
@@ -19963,7 +20726,7 @@ yW
 yW
 yW
 yW
-Mr
+nZ
 wM
 hK
 hK
@@ -20046,7 +20809,7 @@ jX
 Qh
 LJ
 Kh
-ED
+vu
 Oh
 jG
 Ia
@@ -20070,7 +20833,7 @@ fG
 fG
 mN
 mN
-mN
+WB
 mN
 ES
 wa
@@ -20169,7 +20932,7 @@ LJ
 Kh
 ED
 Oh
-jG
+VG
 Gy
 aN
 yW
@@ -20193,7 +20956,7 @@ mN
 mN
 mN
 ep
-wa
+Ax
 wa
 Ip
 SV
@@ -20208,7 +20971,7 @@ yW
 yW
 yW
 hK
-hK
+IH
 hK
 hK
 hK
@@ -20268,7 +21031,7 @@ Je
 gF
 Ec
 mA
-aO
+RU
 Je
 cF
 GN
@@ -20285,7 +21048,7 @@ bD
 bC
 vV
 pQ
-Qh
+xd
 LJ
 Kh
 ED
@@ -20300,14 +21063,14 @@ yW
 yW
 fG
 HT
-HT
+tw
 HT
 fG
-dY
+QQ
 Eu
 fG
 HT
-HT
+tw
 HT
 fG
 ch
@@ -20340,7 +21103,7 @@ yW
 yW
 yW
 hK
-hK
+IH
 hK
 yW
 yW
@@ -20432,7 +21195,7 @@ kE
 VJ
 fG
 wa
-wa
+Ax
 wa
 wa
 mJ
@@ -20546,7 +21309,7 @@ fG
 fG
 fG
 Fu
-BD
+aG
 fG
 fG
 fG
@@ -20624,7 +21387,7 @@ Rl
 Rl
 ro
 Dv
-Rl
+ng
 Rl
 id
 Je
@@ -20644,7 +21407,7 @@ yB
 wp
 So
 ss
-sg
+dQ
 HB
 lG
 vU
@@ -20679,7 +21442,7 @@ Fj
 Fj
 pP
 Sp
-Fj
+tc
 bu
 jt
 Fj
@@ -20689,16 +21452,16 @@ XL
 gU
 ND
 Nx
-Cy
+QL
 Cy
 Cy
 Nx
 vy
 yW
+nZ
 Mr
 Mr
-Mr
-Uv
+ao
 hK
 hK
 IH
@@ -20755,14 +21518,14 @@ LE
 Jn
 VK
 oo
-Rv
+FP
 wc
 wc
 wc
 Rv
 Lc
 tf
-FI
+FS
 Ly
 iB
 ia
@@ -20781,13 +21544,13 @@ gd
 vC
 yb
 yb
-iL
+ev
 tK
 ZD
+hU
 ki
 ki
-ki
-Gf
+uF
 sA
 ki
 ki
@@ -20806,13 +21569,13 @@ Os
 eM
 bX
 AP
-Ky
+gJ
 bU
 AP
 Cy
 Cy
 Cy
-Cy
+QL
 Cy
 yW
 yW
@@ -20867,7 +21630,7 @@ Rl
 ro
 Dv
 lO
-ng
+Rl
 uY
 ll
 BW
@@ -20988,7 +21751,7 @@ Rl
 ro
 cC
 zT
-Rl
+ng
 nn
 Je
 Je
@@ -21044,13 +21807,13 @@ mJ
 mJ
 sL
 rE
-rE
+Ts
 eZ
 mJ
 Vd
 Yy
 La
-jA
+zU
 jA
 jA
 jA
@@ -21121,7 +21884,7 @@ Bs
 yo
 FR
 FR
-FR
+zb
 WO
 KS
 zZ
@@ -21137,16 +21900,16 @@ pv
 wt
 zv
 ye
-Fz
+JW
 Po
 ye
 ai
 ai
-ai
+Pf
 YR
 EA
 fG
-HT
+tw
 HT
 HT
 fG
@@ -21154,12 +21917,12 @@ dY
 vn
 fG
 HT
-HT
+tw
 HT
 fG
 NF
 NF
-NF
+qZ
 NF
 NF
 mJ
@@ -21185,7 +21948,7 @@ yW
 yW
 yW
 wy
-wy
+Sl
 hK
 yW
 yW
@@ -21239,7 +22002,7 @@ zB
 Af
 Dz
 MJ
-sX
+Nk
 Qp
 sX
 Qp
@@ -21255,7 +22018,7 @@ kH
 Eo
 aM
 pv
-pv
+Pw
 wt
 ye
 ZT
@@ -21272,7 +22035,7 @@ HT
 av
 fG
 Fu
-aG
+BD
 fG
 Kb
 HT
@@ -21283,7 +22046,7 @@ NF
 NF
 Xf
 NF
-NF
+qZ
 NF
 oK
 VN
@@ -21299,7 +22062,7 @@ nf
 nf
 Vd
 Ky
-bU
+NW
 Vd
 yW
 yW
@@ -21382,7 +22145,7 @@ ye
 tz
 Yl
 ye
-EA
+yt
 EA
 EA
 EA
@@ -21400,7 +22163,7 @@ MC
 fG
 fG
 NF
-NF
+qZ
 sE
 NF
 NF
@@ -21408,7 +22171,7 @@ NF
 NF
 oK
 VN
-BJ
+bv
 yW
 yW
 yW
@@ -21517,7 +22280,7 @@ xc
 eP
 Lx
 Lx
-Lx
+aY
 rC
 jZ
 sl
@@ -21616,9 +22379,9 @@ Wd
 Pi
 zZ
 jO
-uM
-uM
 nr
+uM
+uM
 uM
 om
 tz
@@ -21631,7 +22394,7 @@ SQ
 bP
 tK
 ZD
-ki
+hU
 ki
 ki
 DR
@@ -21645,19 +22408,19 @@ wf
 wf
 wf
 wf
-HP
+hE
 HP
 wf
-wf
+hQ
 BC
-bv
+BJ
 Cy
 yW
 yW
 yW
 yW
 eu
-Wg
+wF
 Mr
 yW
 Sw
@@ -21670,7 +22433,7 @@ gY
 XB
 Sw
 EX
-eK
+SF
 eK
 DX
 DX
@@ -21786,7 +22549,7 @@ KO
 WK
 rr
 Uh
-rr
+Rw
 dZ
 ek
 Sw
@@ -21851,7 +22614,7 @@ yW
 yW
 yW
 yW
-MR
+MI
 se
 XE
 se
@@ -21863,17 +22626,17 @@ pv
 pv
 BY
 ye
-ZT
+bd
 yS
 ye
 cU
-ae
+lW
 EA
 pO
 sY
 fG
 vd
-HT
+tw
 dc
 fG
 Rt
@@ -21894,7 +22657,7 @@ Nv
 BJ
 BJ
 my
-Mr
+nZ
 WE
 hK
 hK
@@ -21918,12 +22681,12 @@ DX
 te
 sk
 xG
-gK
+xY
 AZ
 UZ
 sk
 sk
-sk
+uq
 CU
 DC
 CU
@@ -22018,7 +22781,7 @@ yW
 Mr
 wM
 hK
-hK
+IH
 hK
 hK
 yW
@@ -22037,7 +22800,7 @@ Db
 DX
 DX
 MG
-sk
+uq
 xG
 gK
 pt
@@ -22122,7 +22885,7 @@ Dy
 Mu
 fG
 VJ
-kE
+Id
 VJ
 fG
 yW
@@ -22130,10 +22893,10 @@ yW
 yW
 NF
 oK
-VN
+Wv
 BJ
 BJ
-Zp
+Er
 yW
 yW
 yW
@@ -22169,7 +22932,7 @@ sk
 Ac
 rH
 Ac
-MG
+Kz
 CU
 MG
 DX
@@ -22195,7 +22958,7 @@ yW
 yW
 yW
 yW
-Af
+Io
 Jh
 yW
 yW
@@ -22232,7 +22995,7 @@ XP
 YC
 Bx
 ye
-FH
+Tm
 CW
 fG
 fG
@@ -22281,7 +23044,7 @@ cR
 vQ
 dl
 fE
-MG
+Kz
 eE
 MU
 MG
@@ -22339,7 +23102,7 @@ yW
 yW
 lp
 Bd
-cp
+hy
 cp
 oH
 lp
@@ -22347,7 +23110,7 @@ nj
 Ss
 zE
 yY
-uh
+Xo
 FF
 re
 BN
@@ -22361,7 +23124,7 @@ yW
 yW
 RD
 FH
-Bq
+Zo
 EA
 yW
 yW
@@ -22379,10 +23142,10 @@ BJ
 Zp
 LS
 hK
+IH
 hK
 hK
-hK
-hK
+IH
 hK
 hK
 yW
@@ -22405,7 +23168,7 @@ Vl
 MG
 MG
 MU
-MG
+Kz
 CU
 MG
 Ac
@@ -22471,7 +23234,7 @@ yY
 tz
 tx
 XP
-EK
+OU
 ck
 ye
 FH
@@ -22496,7 +23259,7 @@ oK
 VN
 BJ
 BJ
-BJ
+bv
 Zp
 Mr
 wM
@@ -22534,7 +23297,7 @@ DX
 MG
 MG
 MG
-MG
+Kz
 DX
 yW
 yW
@@ -22627,7 +23390,7 @@ hK
 hK
 iT
 Mr
-Mr
+nZ
 Sw
 UE
 bj
@@ -22642,14 +23405,14 @@ Cy
 Cy
 DX
 ob
-MG
+Kz
 Bz
 lX
 eE
 JG
 MG
 MG
-MG
+Kz
 CU
 ps
 CU
@@ -22708,7 +23471,7 @@ dJ
 lp
 op
 OK
-FG
+bp
 yY
 tz
 tx
@@ -22727,14 +23490,14 @@ FH
 Ri
 QE
 QE
+Ui
 QE
 QE
-QE
-PV
+mU
 PV
 jl
 sl
-HP
+hE
 VN
 Nv
 BJ
@@ -22744,7 +23507,7 @@ yW
 yW
 yW
 yW
-hK
+IH
 hK
 lY
 Mr
@@ -22752,7 +23515,7 @@ Mr
 KM
 vf
 lA
-lA
+tN
 lA
 sZ
 gR
@@ -22811,7 +23574,7 @@ zJ
 yW
 ja
 se
-Ud
+HQ
 Yx
 yW
 yW
@@ -22835,7 +23598,7 @@ au
 yH
 re
 BN
-KX
+kG
 ye
 FH
 sY
@@ -22876,11 +23639,11 @@ PC
 Qx
 SW
 eI
-lA
+tN
 kK
 Sw
 JM
-tm
+AT
 tm
 DX
 DX
@@ -22953,7 +23716,7 @@ hd
 yY
 ee
 QD
-tx
+HO
 XP
 EK
 ck
@@ -22979,7 +23742,7 @@ ZS
 yW
 yW
 GY
-GY
+jz
 yW
 sN
 sN
@@ -22988,7 +23751,7 @@ py
 py
 LS
 hK
-hK
+IH
 lY
 Mr
 Sw
@@ -23055,7 +23818,7 @@ ja
 ja
 Yx
 Yx
-Yx
+Lf
 Yx
 Yx
 rR
@@ -23066,7 +23829,7 @@ yW
 Rs
 qK
 XM
-Cb
+nJ
 Rc
 Nq
 NQ
@@ -23096,16 +23859,16 @@ cM
 sN
 sN
 XV
-ZS
+yQ
 yW
 yW
 py
 yW
 yW
 sN
-sN
+Sd
 HD
-py
+LU
 GG
 py
 wM
@@ -23125,7 +23888,7 @@ Vc
 eu
 hK
 hK
-wQ
+Vk
 hK
 hK
 IH
@@ -23200,21 +23963,21 @@ XP
 YC
 Bx
 ye
-mH
+mf
 sK
 sN
 sN
 Vb
 py
-mH
+mf
 JI
 CC
+Sd
 sN
 sN
 sN
 sN
-sN
-sN
+Sd
 sN
 XV
 ZS
@@ -23240,10 +24003,10 @@ yW
 Wg
 Mr
 Mr
-Uv
+ao
 hK
 iF
-hK
+IH
 yW
 hK
 hK
@@ -23324,7 +24087,7 @@ ye
 mH
 XZ
 Kw
-Kw
+Yu
 Kw
 Kw
 OO
@@ -23349,7 +24112,7 @@ sN
 Vb
 Qt
 Qt
-py
+LU
 wM
 hK
 yW
@@ -23406,7 +24169,7 @@ yW
 yW
 ja
 zJ
-Yx
+Lf
 zJ
 BR
 BR
@@ -23439,7 +24202,7 @@ Nq
 Hd
 cn
 XP
-EK
+OU
 ck
 ye
 mH
@@ -23465,18 +24228,18 @@ yW
 yW
 yW
 sN
+Sd
 sN
 sN
-sN
-sN
+Sd
 sN
 dz
 LS
 hK
+IH
 hK
 hK
-hK
-hK
+IH
 hK
 hK
 IH
@@ -23535,7 +24298,7 @@ BR
 xp
 nu
 BR
-Yx
+Lf
 zJ
 yW
 ct
@@ -23554,7 +24317,7 @@ UV
 fv
 Rs
 XO
-UV
+rQ
 RJ
 Rs
 gb
@@ -23575,13 +24338,13 @@ oi
 oi
 oi
 oi
-sN
+Sd
 sN
 sN
 sN
 XV
 ZS
-sN
+Sd
 sN
 yW
 yW
@@ -23614,7 +24377,7 @@ yW
 yW
 hK
 hK
-hK
+IH
 hK
 yW
 yW
@@ -23671,7 +24434,7 @@ se
 Nq
 TQ
 eO
-UV
+rQ
 fv
 Rs
 Xk
@@ -23690,7 +24453,7 @@ py
 HR
 sN
 sN
-mH
+mf
 Pp
 dL
 dL
@@ -23700,7 +24463,7 @@ Wj
 dL
 dL
 dL
-XV
+DZ
 ZS
 sN
 sN
@@ -23778,7 +24541,7 @@ RM
 BR
 Yx
 zJ
-Yx
+zJ
 yW
 ct
 Yx
@@ -23802,14 +24565,14 @@ Nq
 EK
 ds
 om
-Sj
+Uz
 kg
 Sj
 Sj
 bn
 py
 HR
-sN
+Sd
 sN
 mH
 Pp
@@ -23817,7 +24580,7 @@ zQ
 Ln
 zK
 NM
-rb
+SH
 rb
 Hx
 zQ
@@ -23947,7 +24710,7 @@ ZS
 sN
 sN
 sN
-sN
+Sd
 sN
 sN
 sN
@@ -23972,10 +24735,10 @@ ef
 Hm
 Hm
 Hm
-eH
+Xi
 Hm
 Hm
-Hm
+Pn
 eH
 yW
 yW
@@ -24013,7 +24776,7 @@ yW
 yW
 ja
 zJ
-Yx
+Lf
 zJ
 WL
 BR
@@ -24057,28 +24820,28 @@ mH
 Pp
 zQ
 hN
-Xr
+VF
 yg
 Qc
 If
 un
 zQ
 XV
-ZS
+yQ
 sN
 sN
 sN
 sN
 sN
 sN
-sN
+Sd
 sN
 sN
 gf
 gA
+mn
 gA
-gA
-gA
+mn
 gA
 ys
 Ob
@@ -24174,7 +24937,7 @@ yW
 yW
 yW
 sN
-mH
+mf
 Pp
 xb
 pT
@@ -24266,7 +25029,7 @@ yW
 yW
 LA
 EQ
-Ud
+HQ
 Yx
 Yx
 tF
@@ -24376,7 +25139,7 @@ yW
 yW
 ja
 zJ
-Yx
+Lf
 Yx
 Yx
 zJ
@@ -24431,10 +25194,10 @@ yW
 sN
 sN
 sN
+Sd
 sN
 sN
-sN
-XV
+DZ
 ZS
 sN
 ys
@@ -24539,7 +25302,7 @@ sN
 sN
 mH
 HL
-sN
+Sd
 sN
 yW
 yW
@@ -24656,7 +25419,7 @@ yW
 yW
 yW
 sN
-sN
+Sd
 sN
 mH
 Pp
@@ -25537,7 +26300,7 @@ yW
 yW
 yW
 Hm
-Hm
+Pn
 Hm
 Hm
 yW
@@ -25900,7 +26663,7 @@ yW
 ja
 eH
 Hm
-Pn
+Hm
 eH
 My
 gw
@@ -26143,7 +26906,7 @@ Ht
 eH
 Pn
 Hm
-Pn
+Hm
 My
 gw
 gw
@@ -26259,7 +27022,7 @@ io
 Dk
 TD
 Hm
-Hm
+Pn
 Ht
 Hm
 Hm
@@ -26626,7 +27389,7 @@ yW
 Hm
 Hm
 Hm
-Hm
+Pn
 Hm
 Eg
 gw
@@ -26743,7 +27506,7 @@ hY
 yW
 Vg
 yW
-Hm
+Pn
 Hm
 eH
 Hm
@@ -26867,7 +27630,7 @@ yW
 Hm
 Hm
 Hm
-Hm
+Pn
 Hm
 Hm
 Eg
@@ -27107,7 +27870,7 @@ yW
 Vg
 yW
 yW
-Hm
+Pn
 Hm
 Hm
 Hm


### PR DESCRIPTION
## `Основные изменения`
На Research Outpost и Orion Outpost были добавлено спавнеры травы для ксеносов.
## `Как это улучшит игру`
Чуть играбельнее карты.
## `Ченджлог`
```
:cl:
map: На Research Outpost и Orion Outpost были добавлено спавнеры травы для ксеносов.
/:cl:
```
