### PR TITLE
Defile now doesn't fail upon target moving. Tentacle now weakens for 2 seconds, but has a wind up. Fixes hive prefixes in xeno names not having a space.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -99,7 +99,7 @@
 		owner.balloon_alert(owner, "Cannot defile")
 		return fail_activate()
 	xeno_owner.face_atom(living_target)
-	if(!do_after(xeno_owner, DEFILER_DEFILE_CHANNEL_TIME, NONE, living_target, BUSY_ICON_HOSTILE))
+	if(!do_after(xeno_owner, DEFILER_DEFILE_CHANNEL_TIME, IGNORE_TARGET_LOC_CHANGE, living_target, BUSY_ICON_HOSTILE))
 		add_cooldown(DEFILER_DEFILE_FAIL_COOLDOWN)
 		return fail_activate()
 	if(!can_use_ability(A))

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -104,8 +104,6 @@
 		return fail_activate()
 	if(!can_use_ability(A))
 		return fail_activate()
-	add_cooldown()
-	xeno_owner.face_atom(living_target)
 	xeno_owner.do_attack_animation(living_target)
 	playsound(living_target, 'sound/effects/spray3.ogg', 15, TRUE)
 	playsound(living_target, pick('sound/voice/alien/drool1.ogg', 'sound/voice/alien/drool2.ogg'), 15, 1)
@@ -155,6 +153,7 @@
 	GLOB.round_statistics.defiler_defiler_stings++
 	SSblackbox.record_feedback(FEEDBACK_TALLY, "round_statistics", 1, "defiler_defiler_stings")
 	succeed_activate()
+	add_cooldown()
 	return ..()
 
 // ***************************************
@@ -555,6 +554,7 @@
 		current = get_step_towards(current, target_turf)
 
 /datum/action/ability/activable/xeno/tentacle/use_ability(atom/movable/target)
+	xeno_owner.face_atom(target)
 	xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name] Power Up"
 	if(!do_after(xeno_owner, 1 SECONDS, IGNORE_TARGET_LOC_CHANGE, target, BUSY_ICON_HOSTILE))
 		xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name] Running"
@@ -564,8 +564,6 @@
 	tentacle = owner.beam(tentacle_end,"curse0",'icons/effects/beam.dmi')
 	RegisterSignals(tentacle_end, list(COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_IMPACT), PROC_REF(finish_grab))
 	tentacle_end.throw_at(target, TENTACLE_ABILITY_RANGE * 1.5, 3, owner, FALSE) //Too hard to hit if just TENTACLE_ABILITY_RANGE
-	succeed_activate()
-	add_cooldown()
 
 ///Signal handler to grab the target when we thentacle head hit something
 /datum/action/ability/activable/xeno/tentacle/proc/finish_grab(datum/source, atom/movable/target)
@@ -574,8 +572,8 @@
 	qdel(source)
 	if(!can_use_ability(target, TRUE, ABILITY_IGNORE_COOLDOWN|ABILITY_IGNORE_PLASMA))
 		owner.balloon_alert(owner, "Grab failed")
-		clear_cooldown()
-		return
+		add_cooldown(5 SECONDS)
+		return fail_activate()
 	tentacle = owner.beam(target, "curse0",'icons/effects/beam.dmi')
 	playsound(target, 'sound/effects/blobattack.ogg', 40, 1)
 	to_chat(owner, span_warning("We grab [target] with a tentacle!"))
@@ -586,6 +584,8 @@
 		var/mob/living/loser = target
 		loser.apply_effect(2 SECONDS, WEAKEN)
 		loser.adjust_stagger(5 SECONDS)
+	succeed_activate()
+	add_cooldown()
 
 ///signal handler to delete tetacle after we are done draggging owner along
 /datum/action/ability/activable/xeno/tentacle/proc/delete_beam(datum/source, atom/impacted)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -555,6 +555,11 @@
 		current = get_step_towards(current, target_turf)
 
 /datum/action/ability/activable/xeno/tentacle/use_ability(atom/movable/target)
+	xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name] Power Up"
+	if(!do_after(xeno_owner, 1 SECONDS, IGNORE_TARGET_LOC_CHANGE, target, BUSY_ICON_HOSTILE))
+		xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name] Running"
+		return fail_activate()
+	xeno_owner.icon_state = "[xeno_owner.xeno_caste.caste_name] Running"
 	var/atom/movable/tentacle_end/tentacle_end = new (get_turf(owner))
 	tentacle = owner.beam(tentacle_end,"curse0",'icons/effects/beam.dmi')
 	RegisterSignals(tentacle_end, list(COMSIG_MOVABLE_POST_THROW, COMSIG_MOVABLE_IMPACT), PROC_REF(finish_grab))
@@ -579,7 +584,7 @@
 	target.throw_at(get_step(owner, owner.dir), TENTACLE_ABILITY_RANGE, 1, owner, FALSE)
 	if(isliving(target))
 		var/mob/living/loser = target
-		loser.ImmobilizeNoChain(1 SECONDS)
+		loser.apply_effect(2 SECONDS, WEAKEN)
 		loser.adjust_stagger(5 SECONDS)
 
 ///signal handler to delete tetacle after we are done draggging owner along

--- a/code/modules/mob/living/carbon/xenomorph/castes/facehugger/facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/facehugger/facehugger.dm
@@ -103,7 +103,7 @@
 			rank_name = "Royal"
 		else
 			rank_name = "Young"
-	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	var/prefix = "[hive.prefix ? "[hive.prefix] " : ""][xeno_caste.upgrade_name ? "[xeno_caste.upgrade_name] " : ""]"
 	name = prefix + "[rank_name ? "[rank_name] " : ""][xeno_caste.display_name] ([nicknumber])"
 
 	real_name = name
@@ -123,8 +123,7 @@
 			return 3
 		if(500 to INFINITY)
 			return 4
-		else
-			return 0
+		return 0
 
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -32,7 +32,7 @@
 
 /mob/living/carbon/xenomorph/king/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
-	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	var/prefix = "[hive.prefix ? "[hive.prefix] " : ""][xeno_caste.upgrade_name ? "[xeno_caste.upgrade_name] " : ""]"
 	if(!client?.prefs.show_xeno_rank || !client)
 		name = prefix + "King ([nicknumber])"
 		real_name = name

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -55,7 +55,7 @@
 		if(100 to INFINITY)
 			progress = "Mature "
 
-	name = "[hive.prefix][progress]Larva ([nicknumber])"
+	name = "[hive.prefix ? "[hive.prefix] " : ""][progress]Larva ([nicknumber])"
 
 	//Update linked data so they show up properly
 	real_name = name

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -73,7 +73,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/queen/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
-	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	var/prefix = "[hive.prefix ? "[hive.prefix] " : ""][xeno_caste.upgrade_name ? "[xeno_caste.upgrade_name] " : ""]"
 	if(!client?.prefs.show_xeno_rank || !client)
 		name = prefix + "Queen ([nicknumber])"
 		real_name = name

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -157,7 +157,7 @@
 /mob/living/carbon/xenomorph/proc/generate_name()
 	var/playtime_mins = client?.get_exp(xeno_caste.caste_name)
 	var/rank_name
-	var/prefix = (hive.prefix || xeno_caste.upgrade_name) ? "[hive.prefix][xeno_caste.upgrade_name] " : ""
+	var/prefix = "[hive.prefix ? "[hive.prefix] " : ""][xeno_caste.upgrade_name ? "[xeno_caste.upgrade_name] " : ""]"
 	if(!client?.prefs.show_xeno_rank || !client)
 		name = prefix + "[xeno_caste.display_name] ([nicknumber])"
 		real_name = name


### PR DESCRIPTION
## `Основные изменения`
Дефайл теперь не проваливается если цель двинулась.
Тентакля теперь ложит на лопатки на 2 секунды, но у неё есть подготовка в 1 секунду и визуальное отображение на самом Дефайлере.

Исправил то что префиксы хайва в именах ксеносов были без пробелов.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Дефайл и Тентакля на данный момент малоюзабельны и излишне ситуативны.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
balance: Дефайл теперь не проваливается если цель двинулась.
balance: Тентакля теперь ложит на лопатки на 2 секунды, но у неё есть подготовка в 1 секунду и визуальное отображение на самом Дефайлере.
fix: Исправил то что префиксы хайва в именах ксеносов были без пробелов.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
