### PR TITLE
M344 pattern ammo load rig in marine vendor

### DIFF
--- a/code/__DEFINES/loadout/gear/field_commander.dm
+++ b/code/__DEFINES/loadout/gear/field_commander.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 	/obj/item/armor_module/module/night_vision = list(CAT_FCSUP, "BE-35 night vision kit", 18, "blue"),
 	/obj/item/clothing/glasses/night_vision = list(CAT_FCSUP, "BE-47 night vision goggles", 26, "blue"),
 	/obj/item/cell/night_vision_battery = list(CAT_FCSUP, "night vision battery", 4, "blue"),
-	/obj/item/storage/belt/marine/auto_catch = list(CAT_FCSUP, "M344 pattern ammo load rig", 10, "orange"),
 	/obj/item/explosive/plastique = list(CAT_FCSUP, "Plastique explosive", 2, "orange3"),
 	/obj/item/detpack = list(CAT_FCSUP, "Detonation pack", 2, "orange3"),
 	/obj/item/storage/box/visual/grenade/sticky = list(CAT_FCSUP, "M40 adhesive charge grenade box", 15, "blue"),

--- a/code/__DEFINES/loadout/gear/leader.dm
+++ b/code/__DEFINES/loadout/gear/leader.dm
@@ -36,7 +36,6 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 	/obj/item/jetpack_marine = list(CAT_LEDSUP, "Jetpack", 5, "yellow"),
 	/obj/item/storage/belt/grenade/b17 = list(CAT_LEDSUP, "High Capacity Grenade Belt", 5, "yellow"),
 	/obj/structure/closet/bodybag/tarp = list(CAT_LEDSUP, "V1 thermal-dampening tarp", 2, "yellow"),
-	/obj/item/storage/belt/marine/auto_catch = list(CAT_LEDSUP, "M344 pattern ammo load rig", 10, "orange"),
 	/obj/item/weapon/gun/flamer/big_flamer/marinestandard = list(CAT_LEDSUP, "FL-84 flamethrower", 6, "red"),
 	/obj/item/ammo_magazine/flamer_tank/large = list(CAT_LEDSUP, "Flamethrower tank", 2, "orange2"),
 	/obj/item/storage/holster/belt/revolver/mateba/full = list(CAT_LEDSUP, "Mateba Autorevolver belt", 10, "red"),

--- a/code/__DEFINES/loadout/gear/marine.dm
+++ b/code/__DEFINES/loadout/gear/marine.dm
@@ -5,7 +5,6 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/implanter/skill/engineer = list(CAT_MARINE, "Engineering skills implanter", 20, "cyan2"),
 	/obj/item/implanter/skill/construct = list(CAT_MARINE, "Construction skills implanter", 20, "cyan2"),
 	/obj/item/storage/backpack/marine/radiopack = list(CAT_MARINE, "Radio Pack", 5, "orange"),
-	/obj/item/storage/belt/marine/auto_catch = list(CAT_MARINE, "M344 pattern ammo load rig", 10, "orange"),
 	/obj/item/stack/sandbags_empty/half = list(CAT_MARINE, "Sandbags x25", SANDBAG_PRICE_IN_GEAR_VENDOR, "orange"),
 	/obj/item/fulton_extraction_pack = list(CAT_MARINE, "Fulton Extraction Pack", 5, "orange"),
 	/obj/item/explosive/grenade = list(CAT_MARINE, "M40 HEDP grenade", 2, "orange3"),

--- a/code/__DEFINES/loadout/gear/smartgunner.dm
+++ b/code/__DEFINES/loadout/gear/smartgunner.dm
@@ -20,5 +20,4 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/ammo_magazine/rifle/sg153/plasmaloss = list(CAT_SGSUP, "SG-153 Spotting Rifle Tanglefoot Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/incendiary = list(CAT_SGSUP, "SG-153 Spotting Rifle Incendiary Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/pistol/p14/smart_pistol = list(CAT_SGSUP, "SP-13 smart pistol ammo", 2, "orange2"),
-	/obj/item/storage/belt/marine/auto_catch = list(CAT_SGSUP, "M344 pattern ammo load rig", 10, "orange"),
 ))

--- a/code/datums/storage/subtypes/belt.dm
+++ b/code/datums/storage/subtypes/belt.dm
@@ -182,7 +182,7 @@
 	))
 
 /datum/storage/belt/marine/auto_catch
-	storage_slots = 4
+	storage_slots = 5
 
 /datum/storage/belt/marine/sectoid/New(atom/parent)
 	. = ..()

--- a/code/game/objects/machinery/vending/marine_vending/uniform.dm
+++ b/code/game/objects/machinery/vending/marine_vending/uniform.dm
@@ -60,6 +60,7 @@
 		),
 		"Belts" = list(
 			/obj/item/storage/belt/marine = -1,
+			/obj/item/storage/belt/marine/auto_catch = -1,
 			/obj/item/storage/belt/shotgun = -1,
 			/obj/item/storage/belt/shotgun/martini = -1,
 			/obj/item/storage/belt/grenade = -1,

--- a/code/modules/reqs/supplypacks/clothing.dm
+++ b/code/modules/reqs/supplypacks/clothing.dm
@@ -22,11 +22,6 @@
 	contains = list(/obj/item/storage/backpack/marine/radiopack)
 	cost = 20
 
-/datum/supply_packs/clothing/auto_catch_belt
-	name = "M344 pattern ammo load rig"
-	contains = list(/obj/item/storage/belt/marine/auto_catch)
-	cost = 50
-
 /datum/supply_packs/clothing/technician_pack
 	name = "Engineering technician pack"
 	contains = list(/obj/item/storage/backpack/marine/tech)


### PR DESCRIPTION
## `Основные изменения`

M344 pattern ammo load rig теперь бесплатный и в общем доступе
повышена вместимость до 5 слотов

## `Как это улучшит игру`

марин бафф

## `Ченджлог`
```
:cl:
add: M344 pattern ammo load rig in The Surplus Clothing Vendor
/:cl:
```
