### PR TITLE
Mortar&Howi buff

### DIFF
--- a/code/modules/projectiles/ammo_datums/artillery.dm
+++ b/code/modules/projectiles/ammo_datums/artillery.dm
@@ -12,7 +12,8 @@
 	bullet_color = COLOR_VERY_SOFT_YELLOW
 
 /datum/ammo/mortar/drop_nade(turf/target_turf)
-	cell_explosion(target_turf, 90, 30)
+	cell_explosion(target_turf, 200, 50)
+	create_shrapnel(target_turf, 15, shrapnel_type = /datum/ammo/bullet/shrapnel/metal)
 
 /datum/ammo/mortar/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	drop_nade(target_turf)
@@ -28,7 +29,7 @@
 	shell_speed = 0.75
 
 /datum/ammo/mortar/knee/drop_nade(turf/target_turf)
-	cell_explosion(target_turf, 80, 30)
+	cell_explosion(target_turf, 120, 30)
 
 /datum/ammo/mortar/smoke
 	///the smoke effect at the point of detonation
@@ -53,7 +54,7 @@
 	icon_state = "howi"
 
 /datum/ammo/mortar/howi/drop_nade(turf/target_turf)
-	cell_explosion(target_turf, 200, 100)
+	cell_explosion(target_turf, 375, 50)
 
 /datum/ammo/mortar/howi/incend/drop_nade(turf/target_turf)
 	cell_explosion(target_turf, 45, 30)


### PR DESCRIPTION
## `Основные изменения`

Усиливает ХЕ снаряды гаубицы и мортиры

## `Как это улучшит игру`

Артиллерией очень сложно точно попасть в ксеноморфа, при этом, даже при прямом попадании до ПРа снаряд гаубицы наносил 200 урона, чего было недостаточно для гиба любого из ксеноморфов.

## `Ченджлог`

Взрыв снаряда мортиры:
cell_explosion(target_turf, 90, 30) > cell_explosion(target_turf, 200, 50); create_shrapnel(target_turf, 15, shrapnel_type = /datum/ammo/bullet/shrapnel/metal)

Взрыв снаряда коленной мортиры:
cell_explosion(target_turf, 80, 30) > cell_explosion(target_turf, 120, 30)

Взрыв снаряда гаубицы:
cell_explosion(target_turf, 200, 100) > cell_explosion(target_turf, 375, 50)

Урон был протестирован на локалке, мортира может гибнуть хилых т1 ксеноморфов при прямом попадании, если им не повезёт и осколки полетят в тайл под ксеноморфом. Следует добавить, что мортира имеет меньшую точность, чем гаубица и точно попасть в ксеноморфа сложно. Гаубица гибает всех ксеноморфов хилее спиттера при прямом попадании, критует ксеноморфов с хп <326 в радиусе 1 тайла от взрыва и ксеноморфов с хп <276 в 2 тайлах от взрыва.
```
:cl:
balance: Бафф ХЕ гаубицы и мортиры
/:cl:
```
