### PR TITLE
Возвращение Мг42

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending/weapon.dm
+++ b/code/game/objects/machinery/vending/marine_vending/weapon.dm
@@ -70,6 +70,8 @@
 			/obj/item/storage/holster/belt/ts34/full = 5,
 		),
 		"Пулемёты" = list(
+			/obj/item/weapon/gun/rifle/mg42 = -1,
+			/obj/item/ammo_magazine/mg42 = -1,
 			/obj/item/weapon/gun/rifle/mg60 = -1,
 			/obj/item/ammo_magazine/mg60 = -1,
 			/obj/item/weapon/gun/mg27 = 5,
@@ -310,6 +312,8 @@
 			/obj/item/storage/holster/belt/ts34/full = 5,
 		),
 		"Пулемёты" = list(
+			/obj/item/weapon/gun/rifle/mg42 = -1,
+			/obj/item/ammo_magazine/mg42 = -1,
 			/obj/item/weapon/gun/rifle/mg60 = -1,
 			/obj/item/ammo_magazine/mg60 = -1,
 			/obj/item/weapon/gun/mg27 = 5,
@@ -542,6 +546,8 @@
 			/obj/item/storage/holster/belt/ts34/full = -1,
 		),
 		"Пулемёты" = list(
+			/obj/item/weapon/gun/rifle/mg42 = -1,
+			/obj/item/ammo_magazine/mg42 = -1,
 			/obj/item/weapon/gun/rifle/mg60 = -1,
 			/obj/item/ammo_magazine/mg60 = -1,
 			/obj/item/weapon/gun/mg27 = -1,


### PR DESCRIPTION
## `Основные изменения`
МГ42 был возвращен в вендоры маринов

## `Как это улучшит игру`
МГ42 это лёгкий пехотный пулемёт под популярный калибр 10x24, он не имбует и не такая уж и хуйня - что может пойти плохо? В пределах некоего маня'баланса' и придает вариативности геймплея

## `Ченджлог`
```
:cl:
add: MG42 был возвращен в вендоры вооружения маринов
/:cl:
```
