### PR TITLE
Стенирезинная ререволюция

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -210,9 +210,9 @@
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SECRETE_RESIN,
 	)
 	///Minimum time to build a resin structure
-	var/base_wait = 1 SECONDS
+	var/base_wait = 0.5 SECONDS
 	///Multiplicator factor to add to the building time, depends on the health of the structure built
-	var/scaling_wait = 1 SECONDS
+	var/scaling_wait = 1.5 SECONDS
 	///List of buildable structures. Order corresponds with resin_images_list.
 	var/list/buildable_structures = list(
 		/turf/closed/wall/resin/regenerating,


### PR DESCRIPTION
## `Основные изменения`
Вернул прежние значения постройки стенок, повысил скейлинг на время постройки стенок еще на 0.5 делений

## `Как это улучшит игру`
На краше будет попроще жить, чуть попозже высру геройский ПР на квикбилд на краше, мне пока лень просто
И это еще сильнее урезает возможность стройки стенок в боевых условиях, что весело и прикольно

## `Ченджлог`

```
:cl:
balance: Уменьшил кулдаун строительства.
balance: Повысил скейлинг кулдауна строительства от полученного урона.
/:cl:
```
