### PR TITLE
Restricts warrior from using grapple toss inside crash fog.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -416,6 +416,10 @@
 		if(!silent)
 			owner.balloon_alert(owner, "Nothing to toss")
 		return FALSE
+	if(!owner.issamexenohive(owner.pulling)) //xenos should be able to fling xenos into xeno passable areas!
+		for(var/obj/effect/forcefield/fog/fog in owner.loc)
+			owner.pulling.balloon_alert(owner, "Cannot, fog")
+			return fail_activate()
 	if(!owner.Adjacent(owner.pulling))
 		if(!silent)
 			owner.balloon_alert(owner, "Target not adjacent")


### PR DESCRIPTION
## `Основные изменения`
Варриор теперь не может прокидывать маров за туман краша.
## `Ченджлог`
```
:cl:
add: Варриор теперь не может прокидывать маров за туман краша.
/:cl:
```
