### PR TITLE
Fixes storage_type_limits not working properly.

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -936,6 +936,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			continue
 		M.client.screen -= item
 
+	if(!QDELETED(item))
+		UnregisterSignal(item, COMSIG_MOVABLE_MOVED)
+		item.on_exit_storage(src)
+		item.mouse_opacity = initial(item.mouse_opacity)
+
 	if(new_location)
 		if(ismob(new_location))
 			item.layer = ABOVE_HUD_LAYER
@@ -954,11 +959,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	for(var/i in can_see_content())
 		var/mob/M = i
 		show_to(M)
-
-	if(!QDELETED(item))
-		UnregisterSignal(item, COMSIG_MOVABLE_MOVED)
-		item.on_exit_storage(src)
-		item.mouse_opacity = initial(item.mouse_opacity)
 
 	for(var/limited_type in storage_type_limits_max)
 		if(istype(item, limited_type))

--- a/code/datums/storage/subtypes/briefcase.dm
+++ b/code/datums/storage/subtypes/briefcase.dm
@@ -14,9 +14,9 @@
 			/obj/item/attachable/scope/standard_magnum,
 			/obj/item/ammo_magazine/revolver/standard_magnum,
 		),
-		storage_type_limits_list = list(/obj/item/weapon/gun)
+		storage_type_limits_list = list(/obj/item/weapon/gun/revolver/standard_magnum)
 	)
-	storage_type_limits_max = list(/obj/item/weapon/gun = 1)
+	storage_type_limits_max = list(/obj/item/weapon/gun/revolver/standard_magnum = 1)
 
 /datum/storage/briefcase/t500
 	max_w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
## `Основные изменения`
`storage_type_limits` теперь работает, то есть нельзя в сумку с садаром поместить 4 садара.
`remove_from_storage` кастовалось 2 раза из-за того что сигнал отменялся слишком поздно.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Исправил работу storage_type_limits, которая влияла на то что ты не мог вместить 4 садара в сумке для 1-ого садара.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
