### PR TITLE
Жизнь нанитчикам!

### DIFF
--- a/code/__DEFINES/loadout/gear/marine.dm
+++ b/code/__DEFINES/loadout/gear/marine.dm
@@ -18,6 +18,8 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/structure/closet/crate/mortar_ammo/mlrs_kit = list(CAT_MARINE, "MLRS kit", 35, "orange3"),
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 14, "cyan"),
+	/obj/item/reagent_containers/hypospray/autoinjector/quickclot = list(CAT_MARINE, "Quickclot autoinjector", 14, "cyan"),
+	/obj/item/reagent_containers/hypospray/advanced/nanoblood = list(CAT_MARINE, "Hypospray (60u Nanoblood)", 16, "cyan"),
 	/obj/vehicle/ridden/motorbike = list(CAT_MARINE, "Bike", 30, "blue"),
 	/obj/item/sidecar = list(CAT_MARINE, "Bike sidecar", 15, "blue"),
 	/obj/item/ammo_magazine/rifle/ar21/extended = list(CAT_MARINE, "AR-21 extended magazine", 14, "blue"),


### PR DESCRIPTION
## `Основные изменения`

Добавление средств жизни нанитчикам на марах

## `Как это улучшит игру`

В данный момент мары, которые юзают наниты имеют только базовые средства восстановления крови (изотоник) и большинство либо просят, либо вынуждены страдать до покупки квик клота и нанокрови.

Добавление квик клота и нанокрови в вендор позволит марам, юзающим нанитный билд покупать себе средства для жизни и не боятся длительных боёв с начала раунда. Я считаю, что совокупная стоимость в 30 поинтов компенсирует повышение качества жизни, ведь не позволяет взять множество других вещей.

## `Ченджлог`

Добавил гипач нанокрови и инжектор квик клота в вендор маров
```
:cl:
add: Добавил квик клот инжектор и гипач нанокрови в вендор маринов.
/:cl:
```
