### PR TITLE
Separate assault rifles and standart rifles

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending/weapon.dm
+++ b/code/game/objects/machinery/vending/marine_vending/weapon.dm
@@ -9,28 +9,30 @@
 	isshared = TRUE
 
 	products = list(
-		"Винтовки" = list(
+		"Автоматы" = list(
 			/obj/item/weapon/gun/rifle/ar12 = -1,
 			/obj/item/ammo_magazine/rifle/ar12 = -1,
 			/obj/item/weapon/gun/rifle/ar18 = -1,
 			/obj/item/ammo_magazine/rifle/ar18 = -1,
 			/obj/item/weapon/gun/rifle/ar11 = -1,
 			/obj/item/ammo_magazine/rifle/ar11 = -1,
+			/obj/item/weapon/gun/rifle/type71 = -1,
+			/obj/item/ammo_magazine/rifle/type71 = -1,
+			/obj/item/weapon/gun/rifle/ar21 = -1,
+			/obj/item/ammo_magazine/rifle/ar21 = -1,
+			/obj/item/weapon/gun/rifle/type16 = -1,
+			/obj/item/ammo_magazine/rifle/type16 = -1,
+			/obj/item/weapon/gun/rifle/type16/m2 = -1,
+			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
+		),
+		"Винтовки" = list(
 			/obj/item/weapon/gun/shotgun/pump/lever/repeater = -1,
 			/obj/item/ammo_magazine/packet/p4570 = -1,
 			/obj/item/weapon/gun/shotgun/double/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini/white = -1,
-			/obj/item/weapon/gun/rifle/type71 = -1,
-			/obj/item/ammo_magazine/rifle/type71 = -1,
-			/obj/item/weapon/gun/rifle/ar21 = -1,
-			/obj/item/ammo_magazine/rifle/ar21 = -1,
 			/obj/item/weapon/gun/revolver/coltrifle = -1,
 			/obj/item/ammo_magazine/revolver/rifle = -1,
-			/obj/item/weapon/gun/rifle/type16 = -1,
-			/obj/item/ammo_magazine/rifle/type16 = -1,
-			/obj/item/weapon/gun/rifle/type16/m2 = -1,
-			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
 		),
 		"Пистолеты-пулемёты" = list(
 			/obj/item/weapon/gun/smg/vector = -1,
@@ -251,28 +253,30 @@
 
 /obj/machinery/vending/weapon/crash
 	products = list(
-		"Винтовки" = list(
+		"Автоматы" = list(
 			/obj/item/weapon/gun/rifle/ar12 = -1,
 			/obj/item/ammo_magazine/rifle/ar12 = -1,
 			/obj/item/weapon/gun/rifle/ar18 = -1,
 			/obj/item/ammo_magazine/rifle/ar18 = -1,
 			/obj/item/weapon/gun/rifle/ar11 = -1,
 			/obj/item/ammo_magazine/rifle/ar11 = -1,
+			/obj/item/weapon/gun/rifle/type71 = -1,
+			/obj/item/ammo_magazine/rifle/type71 = -1,
+			/obj/item/weapon/gun/rifle/ar21 = -1,
+			/obj/item/ammo_magazine/rifle/ar21 = -1,
+			/obj/item/weapon/gun/rifle/type16 = -1,
+			/obj/item/ammo_magazine/rifle/type16 = -1,
+			/obj/item/weapon/gun/rifle/type16/m2 = -1,
+			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
+		),
+		"Винтовки" = list(
 			/obj/item/weapon/gun/shotgun/pump/lever/repeater = -1,
 			/obj/item/ammo_magazine/packet/p4570 = -1,
 			/obj/item/weapon/gun/shotgun/double/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini/white = -1,
-			/obj/item/weapon/gun/rifle/type71 = -1,
-			/obj/item/ammo_magazine/rifle/type71 = -1,
-			/obj/item/weapon/gun/rifle/ar21 = -1,
-			/obj/item/ammo_magazine/rifle/ar21 = -1,
 			/obj/item/weapon/gun/revolver/coltrifle = -1,
 			/obj/item/ammo_magazine/revolver/rifle = -1,
-			/obj/item/weapon/gun/rifle/type16 = -1,
-			/obj/item/ammo_magazine/rifle/type16 = -1,
-			/obj/item/weapon/gun/rifle/type16/m2 = -1,
-			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
 		),
 		"Пистолеты-пулемёты" = list(
 			/obj/item/weapon/gun/smg/vector = -1,
@@ -479,7 +483,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
 	products = list(
-		"Винтовки" = list(
+		"Автоматы" = list(
 			/obj/item/weapon/gun/rifle/ar12 = -1,
 			/obj/item/ammo_magazine/rifle/ar12 = -1,
 			/obj/item/ammo_magazine/rifle/ar12/incendiary = -1,
@@ -487,21 +491,23 @@
 			/obj/item/ammo_magazine/rifle/ar18 = -1,
 			/obj/item/weapon/gun/rifle/ar11 = -1,
 			/obj/item/ammo_magazine/rifle/ar11 = -1,
+			/obj/item/weapon/gun/rifle/type71 = -1,
+			/obj/item/ammo_magazine/rifle/type71 = -1,
+			/obj/item/weapon/gun/rifle/ar21 = -1,
+			/obj/item/ammo_magazine/rifle/ar21 = -1,
+			/obj/item/weapon/gun/rifle/type16 = -1,
+			/obj/item/ammo_magazine/rifle/type16 = -1,
+			/obj/item/weapon/gun/rifle/type16/m2 = -1,
+			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
+		),
+		"Винтовки" = list(
 			/obj/item/weapon/gun/shotgun/pump/lever/repeater = -1,
 			/obj/item/ammo_magazine/packet/p4570 = -1,
 			/obj/item/weapon/gun/shotgun/double/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini = -1,
 			/obj/item/ammo_magazine/rifle/martini/white = -1,
-			/obj/item/weapon/gun/rifle/type71 = -1,
-			/obj/item/ammo_magazine/rifle/type71 = -1,
-			/obj/item/weapon/gun/rifle/ar21 = -1,
-			/obj/item/ammo_magazine/rifle/ar21 = -1,
 			/obj/item/weapon/gun/revolver/coltrifle = -1,
 			/obj/item/ammo_magazine/revolver/rifle = -1,
-			/obj/item/weapon/gun/rifle/type16 = -1,
-			/obj/item/ammo_magazine/rifle/type16 = -1,
-			/obj/item/weapon/gun/rifle/type16/m2 = -1,
-			/obj/item/ammo_magazine/rifle/type16/m2 = -1,
 		),
 		"Пистолеты-пулемёты" = list(
 			/obj/item/weapon/gun/smg/vector = -1,


### PR DESCRIPTION
## `Основные изменения`

Отделены штурмовые винтовки и стандартные винтовки в вендорах

## `Как это улучшит игру`

Визуально разделяет "очередные арки" и винтовки

## `Ченджлог`
```
:cl:
qol: Отделены штурмовые винтовки и стандартные винтовки в вендорах.
/:cl:
```
