### PR TITLE
Vali nuking

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -86,9 +86,9 @@
 		/datum/reagent/medicine/synaptizine = list(NAME = "Synaptizine", REQ = 1, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 1, STAM_REG_AMP = 0.1, SPEED_BOOST = 0),
 		/datum/reagent/medicine/neuraline = list(NAME = "Neuraline", REQ = 2, BRUTE_AMP = 1, BURN_AMP = 1, TOX_HEAL = -3, STAM_REG_AMP = 0, SPEED_BOOST = -0.3),
 		/datum/reagent/toxin/xeno_hemodile = list(NAME = "Hemodile", REQ = 3, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = -0.2, SPEED_BOOST = 0.2),
-		/datum/reagent/toxin/xeno_transvitox = list(NAME = "Transvitox", REQ = 3, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = -0.3, STAM_REG_AMP = 0, SPEED_BOOST = 0),
-		/datum/reagent/toxin/xeno_sanguinal = list(NAME = "Sanguinal", REQ = 3, BRUTE_AMP = -0.3, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
-		/datum/reagent/toxin/xeno_ozelomelyn = list(NAME = "Ozelomelyn", REQ = 3, BRUTE_AMP = -0.2, BURN_AMP = -0.2, TOX_HEAL = -0.2, STAM_REG_AMP = 0, SPEED_BOOST = 0),
+		/datum/reagent/toxin/xeno_transvitox = list(NAME = "Transvitox", REQ = 3, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = -0.5, STAM_REG_AMP = 0, SPEED_BOOST = 0),
+		/datum/reagent/toxin/xeno_sanguinal = list(NAME = "Sanguinal", REQ = 3, BRUTE_AMP = -0.4, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
+		/datum/reagent/toxin/xeno_ozelomelyn = list(NAME = "Ozelomelyn", REQ = 3, BRUTE_AMP = -0.5, BURN_AMP = -0.5, TOX_HEAL = -0.2, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/toxin/satrapine = list(NAME = "Satrapine", REQ = 3, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = -0.3, STAM_REG_AMP = -0.3, SPEED_BOOST = 0),
 	)
 
@@ -193,7 +193,7 @@
 		return
 	update_resource(-resource_drain_amount)
 
-	wearer.adjustToxLoss(-tox_heal*boost_amount)
+	wearer.adjust_tox_loss(-tox_heal*boost_amount)
 	wearer.heal_overall_damage(4*boost_amount*brute_heal_amp, 4*boost_amount*burn_heal_amp)
 	vali_necro_timer = world.time - processing_start
 	if(vali_necro_timer > 20 SECONDS)

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -193,8 +193,8 @@
 		return
 	update_resource(-resource_drain_amount)
 
-	wearer.adjust_tox_loss(-tox_heal*boost_amount)
-	wearer.heal_overall_damage(4*boost_amount*brute_heal_amp, 4*boost_amount*burn_heal_amp)
+	wearer.adjust_tox_loss(-tox_heal * boost_amount)
+	wearer.heal_overall_damage(4 * boost_amount * brute_heal_amp, 4 * boost_amount * burn_heal_amp)
 	vali_necro_timer = world.time - processing_start
 	if(vali_necro_timer > 20 SECONDS)
 		return

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -80,8 +80,8 @@
 		/datum/reagent/medicine/bicaridine = list(NAME = "Bicaridine", REQ = 5, BRUTE_AMP = 0.1, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/kelotane = list(NAME = "Kelotane", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0.1, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/paracetamol = list(NAME = "Paracetamol", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0.2, SPEED_BOOST = -0.1),
-		/datum/reagent/medicine/meralyne = list(NAME = "Meralyne", REQ = 5, BRUTE_AMP = 0.2, BURN_AMP = 0, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
-		/datum/reagent/medicine/dermaline = list(NAME = "Dermaline", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0.2, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
+		/datum/reagent/medicine/meralyne = list(NAME = "Meralyne", REQ = 5, BRUTE_AMP = 0.2, BURN_AMP = -0.1, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
+		/datum/reagent/medicine/dermaline = list(NAME = "Dermaline", REQ = 5, BRUTE_AMP = -0.1, BURN_AMP = 0.2, TOX_HEAL = 0, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/dylovene = list(NAME = "Dylovene", REQ = 5, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 0.5, STAM_REG_AMP = 0, SPEED_BOOST = 0),
 		/datum/reagent/medicine/synaptizine = list(NAME = "Synaptizine", REQ = 1, BRUTE_AMP = 0, BURN_AMP = 0, TOX_HEAL = 1, STAM_REG_AMP = 0.1, SPEED_BOOST = 0),
 		/datum/reagent/medicine/neuraline = list(NAME = "Neuraline", REQ = 2, BRUTE_AMP = 1, BURN_AMP = 1, TOX_HEAL = -3, STAM_REG_AMP = 0, SPEED_BOOST = -0.3),
@@ -193,8 +193,8 @@
 		return
 	update_resource(-resource_drain_amount)
 
-	wearer.adjust_tox_loss(-tox_heal * boost_amount)
-	wearer.heal_overall_damage(6 * boost_amount*brute_heal_amp, 6 * boost_amount * burn_heal_amp)
+	wearer.adjustToxLoss(-tox_heal*boost_amount)
+	wearer.heal_overall_damage(4*boost_amount*brute_heal_amp, 4*boost_amount*burn_heal_amp)
 	vali_necro_timer = world.time - processing_start
 	if(vali_necro_timer > 20 SECONDS)
 		return


### PR DESCRIPTION
## `Основные изменения`
Ports https://github.com/tgstation/TerraGov-Marine-Corps/pull/16929

1. Теперь ксеновские реагенты взаимодействуют с вали-модулем. 
   - Трансвитокс : `toxin heal -0.5`
   - Сангвинал: `brute heal -40%`
   - Ози: `brute/burn heal -50%, toxin heal -0.3`
   - Хемо: `stam regen -20%, slowdown +0.2`

2. Урезан мультиплаер хила с 6 до 4. 

Баланс сделан в соответствие с отсутствием нейротокса у нас. Конструктивное решение заместо удаление вали рапиры.

## `Как это улучшит игру`

Хотя у Вали есть различные комбинации и стратегии, все его проблемы в конечном итоге проистекают из невероятно высокой силы лечения, которую можно из него извлечь. Он позволяет перелечивать урон от ксеносов, часто даже в бою с несколькими одновременно.

Для справки: пиковая сила лечения Вали примерно в 2-3 раза выше, чем у Russian Red (и это даже без учёта нейралина, который представляет собой совершенно отдельную историю).

Поэтому вместо того, чтобы пытаться точечно исправлять конкретные проблемные сценарии, это предложение просто снижает силу лечения и добавляет элементы контрстратегии для ксеносов.

Снижение стандартного множителя помогает ограничить лечение от достижения абсурдных уровней, при этом всё ещё оставляя его значительно более мощным, чем не-валиумное лечение.

Добавление отрицательных множителей для ксено-реагентов даёт ксеносам степень контроля над валиумом, вместо того чтобы просто быть DPS check кто кого перебьет.

Изменение Мерадерма означает, что если у вас есть доступ к медицине второго тира, вы не можете просто бездумно колоть все реагенты подряд для получения дополнительных бонусов поверх самого лечения второго тира. Это заставляет пользователя валиума хотя бы немного задумываться о том, какие реагенты использовать.

## `Ченджлог`
```
:cl:
add: Вали реагирует с ксено реагентами.
balance: Изменил heal multiplier у вали.
/:cl:
```
