### PR TITLE
Tank ammo now sets to maximum available number by default. Beds now drop metal on destruction by attack.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -47,6 +47,11 @@
 		unbuckle_bodybag()
 	return ..()
 
+/obj/structure/bed/deconstruct(disassembled, mob/living/blame_mob)
+	if(buildstacktype && dropmetal)
+		new buildstacktype(loc, buildstackamount)
+	return ..()
+
 /obj/structure/bed/post_buckle_mob(mob/buckling_mob)
 	. = ..()
 	buckling_mob.pixel_y = buckling_y

--- a/code/modules/reqs/ui/vehicle.dm
+++ b/code/modules/reqs/ui/vehicle.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			var/list/assoc_cast = GLOB.armored_gunammo[newtype]
 			primary_ammo = assoc_cast.Copy()
 			for(var/ammo in primary_ammo)
-				primary_ammo[ammo] = 0
+				primary_ammo[ammo] = trunc(20 / length(primary_ammo))
 			. = TRUE
 
 		if("setsecondary")
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			var/list/assoc_cast = GLOB.armored_gunammo[newtype]
 			secondary_ammo = assoc_cast.Copy()
 			for(var/ammo in secondary_ammo)
-				secondary_ammo[ammo] = 0
+				secondary_ammo[ammo] = trunc(20 / length(secondary_ammo))
 			. = TRUE
 
 		if("set_ammo_primary")

--- a/code/modules/reqs/ui/vehicle.dm
+++ b/code/modules/reqs/ui/vehicle.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			var/list/assoc_cast = GLOB.armored_gunammo[newtype]
 			primary_ammo = assoc_cast.Copy()
 			for(var/ammo in primary_ammo)
-				primary_ammo[ammo] = trunc(20 / length(primary_ammo))
+				primary_ammo[ammo] = trunc(DEFAULT_MAX_ARMORED_AMMO / length(primary_ammo))
 			. = TRUE
 
 		if("setsecondary")
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(purchased_tanks)
 			var/list/assoc_cast = GLOB.armored_gunammo[newtype]
 			secondary_ammo = assoc_cast.Copy()
 			for(var/ammo in secondary_ammo)
-				secondary_ammo[ammo] = trunc(20 / length(secondary_ammo))
+				secondary_ammo[ammo] = trunc(DEFAULT_MAX_ARMORED_AMMO / length(secondary_ammo))
 			. = TRUE
 
 		if("set_ammo_primary")


### PR DESCRIPTION
## `Основные изменения`
При заказе тяжёлой техники значения боеприпасов для пушек выставляются на возможный максимум, для предотвращения отсутствия боеприпасов у новичков.
Исправил то что стулья водителей танка можно было уничтожить взрывом.

Разрушение кроватей/стульев теперь оставляет на их месте материал из которого они сделаны.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Защита от дураков, которые потом клянчат у админов патроны в ахелп.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
add: При заказе тяжёлой техники значения боеприпасов для пушек выставляются на возможный максимум, для предотвращения отсутствия боеприпасов у новичков.
add: Разрушение кроватей/стульев теперь оставляет на их месте материал из которого они сделаны.
fix: Исправил то что стулья водителей танка можно было уничтожить взрывом.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
