### PR TITLE
Прицел лазснайпы теперь снимается

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -768,7 +768,7 @@
 		/obj/item/attachable/bayonetknife,
 		/obj/item/attachable/bayonetknife/som,
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/unremovable/laser_sniper_scope,
+		/obj/item/attachable/scope/laser_sniper_scope,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,


### PR DESCRIPTION
## `Основные изменения`

Прицел лазснайпы теперь снимается, что даёт вешать другие модули.
## `Как это улучшит игру`
Больше модулей на лазснайпу

## `Ченджлог`
```
:cl:

add: Прицел с лазснайпы теперь снимается.

/:cl:
```
