### PR TITLE
Restricts xenos from stealing items from storages.

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -287,7 +287,7 @@
 	screen_loc = "7,7 to 10,8"
 
 /atom/movable/screen/storage/Click(location, control, params)
-	if(usr.incapacitated(TRUE))
+	if(!ishuman(usr) || usr.incapacitated(TRUE))
 		return
 
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
## `Основные изменения`
Исправил то что ксеноморфы могли украсть предметы из контейнеров если нажимали на сам слот инвентаря, вместо предмета.
## `Как это улучшит игру`
Для отыгрыша руни нужно чтобы было примо, да.
## `Ченджлог`
```
:cl:
fix: Исправил то что ксеноморфы могли украсть предметы из контейнеров если нажимали на сам слот инвентаря, вместо предмета.
/:cl:
```
