### PR TITLE
Бафф ресерчера

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -276,8 +276,6 @@ GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 
 #define isreagentcontainer(A) (istype(A, /obj/item/reagent_containers)) //Checks for if something is a reagent container.
 
-#define is_research_product(A) (istype(A, /obj/item/research_product)) //Checks if item is research item
-
 #define isearthpillar(A) (istype(A, /obj/structure/earth_pillar))
 
 #define isfire(A) (istype(A, /obj/fire))

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -38,38 +38,38 @@
 	var/static/list/rewards_lists = list(
 		RES_MONEY = list(
 			RES_TIER_BASIC = list(
-				/obj/item/research_product/money/basic,
-				/obj/item/research_product/money/common,
+				50, // Basic credits
+				150, // Common credits
 			),
 			RES_TIER_COMMON = list(
-				/obj/item/research_product/money/common,
-				/obj/item/research_product/money/uncommon,
+				150, // Common credits
+				250, // Uncommon credits
 			),
 			RES_TIER_UNCOMMON = list(
-				/obj/item/research_product/money/uncommon,
+				250, // Uncommon credits
 				/obj/item/implanter/blade,
 				/obj/item/attachable/shoulder_mount,
 			),
 			RES_TIER_RARE = list(
-				/obj/item/research_product/money/rare,
+				800, // Rare credits
 			),
 		),
 		RES_XENO = list(
 			RES_TIER_BASIC = list(
-				/obj/item/research_product/money/basic,
-				/obj/item/research_product/money/common,
+				50, // Basic credits
+				150, // Common credits
 			),
 			RES_TIER_COMMON = list(
-				/obj/item/research_product/money/uncommon,
+				250, // Uncommon credits
 			),
 			RES_TIER_UNCOMMON = list(
-				/obj/item/research_product/money/uncommon,
+				250, // Uncommon credits
 				/obj/item/implanter/chem/blood,
 				/obj/item/implanter/cloak,
 				/obj/item/attachable/shoulder_mount,
 			),
 			RES_TIER_RARE = list(
-				/obj/item/research_product/money/rare,
+				800, // Rare credits
 			),
 		),
 	)
@@ -133,9 +133,15 @@
 			"rewards_list" = list(),
 		)
 
-		var/list/tier_rewards_typepaths = research_rewards[tier]
-		for(var/obj/typepath AS in tier_rewards_typepaths)
-			reward_tier["rewards_list"] += initial(typepath.name)
+		var/list/tier_rewards = research_rewards[tier]
+		for(var/reward in tier_rewards)
+			if(isnum(reward))
+				// Direct point value
+				reward_tier["rewards_list"] += "[reward] credits"
+			else
+				// Item typepath - cast to proper type for initial()
+				var/obj/item_type = reward
+				reward_tier["rewards_list"] += initial(item_type.name)
 
 		.["init_resource"]["rewards"] += list(reward_tier)
 
@@ -205,8 +211,24 @@
 	generate_research_rewards_list(resource, potential_rewards, earned_rewards)
 
 	var/turf/drop_loc = get_turf(rewards_position)
-	for (var/obj/item AS in earned_rewards)
-		item.forceMove(drop_loc)
+	var/total_points = 0
+
+	for (var/reward in earned_rewards)
+		if(isnum(reward))
+			// Direct point value - add to supply points
+			total_points += reward
+			SSpoints.supply_points[usr.faction] += reward
+			GLOB.round_statistics.points_from_research += reward
+		else if(istype(reward, /obj/item))
+			// Physical item - drop at location
+			var/obj/item/item = reward
+			item.forceMove(drop_loc)
+
+	// Show message about points earned if any
+	if(total_points > 0)
+		var/datum/export_report/export_report = new /datum/export_report(total_points, "Research: [resource.name]", usr.faction)
+		SSpoints.export_history += export_report
+		visible_message(span_notice("[src] buzzes: Research completed and generated [total_points] point[total_points == 1 ? "" : "s"]."))
 
 ///Generates rewards using the resource's rarity modifiers and a list of potential rewards
 /obj/machinery/researchcomp/proc/generate_research_rewards_list(obj/item/research_resource/resource, list/potential_rewards, list/earned_rewards)
@@ -217,9 +239,16 @@
 
 		var/list/tier_rewards = potential_rewards[tier]
 		//getting random item from the list of items at the tier
-		var/item_typepath = pick(tier_rewards)
-		var/obj/item = new item_typepath
-		earned_rewards += item
+		var/reward = pick(tier_rewards)
+
+		// Handle both direct point values and item typepaths
+		if(isnum(reward))
+			// Direct point value - add to a special list for point tracking
+			earned_rewards += reward
+		else
+			// Item typepath - create the actual item
+			var/obj/item = new reward
+			earned_rewards += item
 
 ///
 ///Research materials
@@ -298,38 +327,4 @@
 		RES_TIER_RARE = 50,
 	)
 
-///
-///Items designed to be products of research
-///It isn't required for a product of research to be subtype of these
-///
 
-/obj/item/research_product
-	name = "money"
-	icon_state = "coin_uranium"
-	///Points provided for exporting the product
-	var/export_points = 1
-
-/obj/item/research_product/supply_export(faction_selling)
-	SSpoints.supply_points[faction_selling] += export_points
-	GLOB.round_statistics.points_from_research += export_points
-	return new /datum/export_report(export_points, name, faction_selling)
-
-/obj/item/research_product/money/basic
-	name = "50 credits coin"
-	desc = "A coin containing rare materials worth for 50 credits."
-	export_points = 50
-
-/obj/item/research_product/money/common
-	name = "150 credits coin"
-	desc = "A coin containing rare materials worth for 150 credits."
-	export_points = 150
-
-/obj/item/research_product/money/uncommon
-	name = "250 credits coin"
-	desc = "A coin containing rare materials worth for 250 credits."
-	export_points = 250
-
-/obj/item/research_product/money/rare
-	name = "800 credits coin"
-	desc = "A coin containing rare materials worth for 800 credits."
-	export_points = 800

--- a/code/game/objects/machinery/sellingpad.dm
+++ b/code/game/objects/machinery/sellingpad.dm
@@ -45,8 +45,6 @@
 				to_chat(user, span_warning("[src] buzzes: This bounty is not dead and cannot be sold."))
 				continue
 			can_sell = TRUE
-		if(is_research_product(onpad))
-			can_sell = TRUE
 		if(!can_sell)
 			continue
 		var/datum/export_report/export_report = onpad.supply_export(user.faction)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -115,6 +115,4 @@
 
 	fade_out(src, our_time = 5 SECONDS)
 	sleep(5 SECONDS)
-	if(prob(25))
-		new /obj/item/research_product/money/basic(loc)
 	qdel(src)


### PR DESCRIPTION
## `Основные изменения`
Теперь ресерч консоль вместо выдачи монеток сразу либо выдаются вещи либо на карго начисляется бабло

## `Как это улучшит игру`
Ввиду назревающего вырезания буров необходимо повысить актуальность ресерчера 

## `Ченджлог`
```
:cl:
qol: Теперь колба ученых сразу продает исследовательский материал в карго.
/:cl:
```
