### PR TITLE
Nerfs poddoors and shutters bullet and laser armor. Photocopier and fax machine are now slashable.

### DIFF
--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -3,7 +3,7 @@
 	desc = "That looks like it doesn't open easily."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = "pdoor1"
-	soft_armor = list(MELEE = 50, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 50, BIO = 100, FIRE = 100, ACID = 70)
+	soft_armor = list(MELEE = 50, BULLET = 90, LASER = 90, ENERGY = 100, BOMB = 50, BIO = 100, FIRE = 100, ACID = 70)
 	layer = PODDOOR_OPEN_LAYER
 	open_layer = PODDOOR_OPEN_LAYER
 	closed_layer = PODDOOR_CLOSED_LAYER

--- a/code/game/objects/machinery/fax.dm
+++ b/code/game/objects/machinery/fax.dm
@@ -8,6 +8,8 @@
 	idle_power_usage = 30
 	active_power_usage = 200
 	power_channel = EQUIP
+	max_integrity = 150
+	resistance_flags = XENO_DAMAGEABLE
 	var/obj/item/card/id/idscan = null
 	var/authenticated = FALSE
 	var/obj/item/paper/message = null

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -8,7 +8,8 @@
 	idle_power_usage = 30
 	active_power_usage = 200
 	power_channel = EQUIP
-	max_integrity = 300
+	max_integrity = 150
+	resistance_flags = XENO_DAMAGEABLE
 	var/obj/item/paper/copy
 	var/obj/item/photo/photocopy
 	var/copies = 1


### PR DESCRIPTION
## `Основные изменения`
Броня створок и ставней уменьшена для пуль и лазеров со 100 до 90.

Фотокопировальную машину и факс теперь можно сломать за ксеноса.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Стены можно спокойно сломать с помощью пуль, но створки при этом можно сломать только с помощью кислоты или взрыва.

Факс и фотокопировальный аппарат просто мешаются ксеносам, из-за того что их нельзя нормально сломать, но при этом можно расстрелять, расплавить или взорвать.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
balance: Броня створок и ставней уменьшена для пуль и лазеров со 100 до 90.
balance: Фотокопировальную машину и факс теперь можно сломать за ксеноса.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
