### PR TITLE
Fixes custom autoinjectors losing icon and name on refill.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -276,11 +276,14 @@
 				if(!name)
 					return
 				var/obj/item/reagent_containers/hypospray/autoinjector/fillable/P = new/obj/item/reagent_containers/hypospray/autoinjector/fillable(loc)
-				if(!name) name = reagents.get_master_reagent_name()
+				if(!name)
+					name = reagents.get_master_reagent_name()
 				P.name = "[name] autoinjector"
+				P.base_name = "[name] autoinjector"
 				P.pixel_x = rand(-7, 7) //random position
 				P.pixel_y = rand(-7, 7)
 				P.icon_state = "autoinjector-"+autoinjectorsprite
+				P.base_icon_state = "autoinjector-"+autoinjectorsprite
 				reagents.trans_to(P,30)
 				P.update_icon()
 

--- a/code/modules/reagents/reagent_containers/autoinjectors.dm
+++ b/code/modules/reagents/reagent_containers/autoinjectors.dm
@@ -10,16 +10,23 @@
 	volume = 45
 	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 45)
 	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 45)
+	///For keeping the initial name of the autoinjector, and not setting back to general autoinjector
+	var/base_name
+
+/obj/item/reagent_containers/hypospray/autoinjector/Initialize(mapload)
+	. = ..()
+	base_icon_state = icon_state
+	base_name = name
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon_state()
 	. = ..()
 	if(!(reagents?.total_volume) && is_drawable())
-		icon_state += "X"
-		name = "expended [name]" //So people can see what have been expended since we have smexy new sprites people aren't used too...
+		icon_state = "[base_icon_state]X"
+		name = "expended [base_name]"
 		DISABLE_BITFIELD(reagents.reagent_flags, DRAWABLE)
 	else if(reagents?.total_volume && !CHECK_BITFIELD(reagents.reagent_flags, DRAWABLE)) // refilling it somehow
-		icon_state = initial(icon_state)
-		name = initial(name)
+		icon_state = base_icon_state
+		name = base_name
 		ENABLE_BITFIELD(reagents.reagent_flags, DRAWABLE)
 
 /obj/item/reagent_containers/hypospray/autoinjector/examine(mob/user)


### PR DESCRIPTION
## `Основные изменения`
Исправил то что кастомные инжекторы теряли иконку и имя после повторного заполнения.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Исправил то что кастомные инжекторы теряли иконку и имя после повторного заполнения.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
