### PR TITLE
Fixes crash cinematic. Makes cleanup time for cinematics 15 seconds.

### DIFF
--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -51,14 +51,13 @@ GLOBAL_LIST_EMPTY(cinematics)
 /datum/cinematic/Destroy()
 	GLOB.cinematics -= src
 	QDEL_NULL(screen)
-	for(var/mob/M in locked)
+	for(var/mob/M as anything in locked)
 		M.notransform = FALSE
 	return ..()
 
 /datum/cinematic/proc/play(watchers)
 	//Check if you can actually play it (stop mob cinematics for global ones) and create screen objects
-	for(var/A in GLOB.cinematics)
-		var/datum/cinematic/C = A
+	for(var/datum/cinematic/C as anything in GLOB.cinematics)
 		if(C == src)
 			continue
 		if(C.is_global || !is_global)
@@ -74,8 +73,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 		ooc_toggled = TRUE
 		GLOB.ooc_allowed = FALSE
 
-	for(var/i in GLOB.mob_list)
-		var/mob/M = i
+	for(var/mob/M as anything  in GLOB.mob_list)
 		if(M in watchers)
 			M.notransform = TRUE //Should this be done for non-global cinematics or even at all ?
 			locked += M
@@ -96,9 +94,9 @@ GLOBAL_LIST_EMPTY(cinematics)
 /datum/cinematic/proc/cinematic_sound(s)
 	if(is_global)
 		SEND_SOUND(world, s)
-	else
-		for(var/C in watching)
-			SEND_SOUND(C, s)
+		return
+	for(var/C as anything in watching)
+		SEND_SOUND(C, s)
 
 ///Fire up special callback for actual effects synchronized with animation (eg real nuke explosion happens midway)
 /datum/cinematic/proc/special()

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -21,7 +21,6 @@ GLOBAL_LIST_EMPTY(cinematics)
 
 /atom/movable/screen/cinematic
 	icon = 'icons/effects/station_explosion.dmi'
-	icon_state = "station_intact"
 	plane = SPLASHSCREEN_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	screen_loc = "CENTER-7,CENTER-7"
@@ -35,6 +34,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 	///Global cinematics will override mob-specific ones
 	var/is_global = FALSE
 	var/atom/movable/screen/cinematic/screen
+	var/screen_icon_state = "station_intact"
 	///For special effects synced with animation (explosions after the countdown etc)
 	var/datum/callback/special_callback
 	///How long it runs for
@@ -47,6 +47,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 /datum/cinematic/New()
 	GLOB.cinematics += src
 	screen = new(src)
+	screen.icon_state = screen_icon_state
 
 /datum/cinematic/Destroy()
 	GLOB.cinematics -= src
@@ -121,19 +122,23 @@ GLOBAL_LIST_EMPTY(cinematics)
 
 /datum/cinematic/nuke
 	runtime = 3.5 SECONDS
+	cleanup_time = 15 SECONDS
+	var/intro_icon = "intro_nuke"
 	var/icon_to_flick = "station_explode_fade_red"
 	var/sound_to_play = 'sound/effects/explosion/far0.ogg'
 	var/summary_icon_state = "summary_nukewin"
 
 /datum/cinematic/nuke/pre_content()
-	flick("intro_nuke", screen)
+	flick(intro_icon, screen)
 	addtimer(CALLBACK(src, PROC_REF(content)), runtime)
 
 /datum/cinematic/nuke/content()
-	flick(icon_to_flick, screen)
+	if(icon_to_flick)
+		flick(icon_to_flick, screen)
 	cinematic_sound(sound(sound_to_play, channel = CHANNEL_CINEMATIC))
 	special()
-	screen.icon_state = summary_icon_state
+	if(summary_icon_state)
+		screen.icon_state = summary_icon_state
 
 /datum/cinematic/nuke/win
 	id = CINEMATIC_NUKE_WIN
@@ -149,11 +154,8 @@ GLOBAL_LIST_EMPTY(cinematics)
 
 /datum/cinematic/nuke/selfdestruct_miss
 	id = CINEMATIC_SELFDESTRUCT_MISS
-
-/datum/cinematic/nuke/selfdestruct_miss/content()
-	cinematic_sound(sound('sound/effects/explosion/far0.ogg', channel = CHANNEL_CINEMATIC))
-	special()
-	screen.icon_state = "station_intact"
+	icon_to_flick = ""
+	summary_icon_state = "station_intact"
 
 /datum/cinematic/nuke/annihilation
 	id = CINEMATIC_ANNIHILATION
@@ -161,49 +163,31 @@ GLOBAL_LIST_EMPTY(cinematics)
 
 /datum/cinematic/nuke/fake
 	id = CINEMATIC_NUKE_FAKE
-	cleanup_time = 10 SECONDS
-
-/datum/cinematic/nuke/fake/content()
-	cinematic_sound(sound('sound/items/bikehorn.ogg', channel = CHANNEL_CINEMATIC))
-	flick("summary_selfdes", screen)
-	special()
+	icon_to_flick = "summary_selfdes"
+	sound_to_play = 'sound/items/bikehorn.ogg'
+	summary_icon_state = ""
 
 /datum/cinematic/nuke/no_core
 	id = CINEMATIC_NUKE_NO_CORE
-	cleanup_time = 10 SECONDS
-
-/datum/cinematic/nuke/no_core/content()
-	flick("station_intact", screen)
-	cinematic_sound(sound('sound/ambience/signal.ogg', channel = CHANNEL_CINEMATIC))
-
-/datum/cinematic/nuke_far
-	id = CINEMATIC_NUKE_FAR
-	cleanup_time = 0
-
-/datum/cinematic/nuke_far/content()
-	cinematic_sound(sound('sound/effects/explosion/far0.ogg', channel = CHANNEL_CINEMATIC))
-	special()
+	icon_to_flick = "station_intact"
+	sound_to_play = 'sound/ambience/signal.ogg'
+	summary_icon_state = ""
 
 /datum/cinematic/nuke/crash
 	id = CINEMATIC_CRASH_NUKE
-	cleanup_time = 15 SECONDS
+	screen_icon_state = "planet_start"
+	intro_icon = "planet_start"
 	icon_to_flick = "planet_nuke"
 	summary_icon_state = "planet_end"
 
-/datum/cinematic/nuke/crash/pre_content()
-	screen.icon_state = "planet_start"
-	return ..()
+/datum/cinematic/nuke/far
+	id = CINEMATIC_NUKE_FAR
+	icon_to_flick = ""
+	summary_icon_state = ""
 
-/datum/cinematic/malf
+/datum/cinematic/nuke/malf
 	id = CINEMATIC_MALF
 	runtime = 7.6 SECONDS
-
-/datum/cinematic/malf/pre_content()
-	flick("intro_malf", screen)
-	addtimer(CALLBACK(src, PROC_REF(content)), runtime)
-
-/datum/cinematic/malf/content()
-	flick("station_explode_fade_red", screen)
-	cinematic_sound(sound('sound/effects/explosion/far0.ogg', channel = CHANNEL_CINEMATIC))
-	special()
-	screen.icon_state = "summary_malf"
+	intro_icon = "intro_malf"
+	icon_to_flick = "station_explode_fade_red"
+	summary_icon_state = "summary_malf"

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -377,5 +377,7 @@
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, gib))
+		//INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, gib)) // in my dreams it will gib marines
+		victim.adjust_fire_loss(victim.maxHealth * 4)
+		victim.death()
 		CHECK_TICK

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -154,8 +154,7 @@
 
 	log_game("Bioscan. Humans: [numHostsPlanet] on the planet[host_location_planetside ? " Location:[host_location_planetside]":""] and [numHostsShip] on the ship.[host_location_shipside ? " Location: [host_location_shipside].":""] Xenos: [xenos_planetside] on the planet and [numXenosShip] on the ship[xeno_location_planetside ? " Location:[xeno_location_planetside]":""] and [numXenosTransit] in transit.")
 
-	for(var/i in GLOB.observer_list)
-		var/mob/M = i
+	for(var/mob/M as anything in GLOB.observer_list)
 		to_chat(M, assemble_alert(
 			title = "Биосканирование Завершено",
 			message = {"[numXenosPlanet] ксеносов на земле.
@@ -219,7 +218,6 @@
 		return TRUE
 	return FALSE
 
-
 /datum/game_mode/infestation/declare_completion()
 	. = ..()
 	log_game("[round_finished]\nGame mode: [name]\nRound time: [duration2text()]\nEnd round player population: [length(GLOB.clients)]\nTotal xenos spawned: [GLOB.round_statistics.total_xenos_created]\nTotal humans spawned: [GLOB.round_statistics.total_humans_created]")
@@ -265,16 +263,13 @@
 	ghost_track = sound(ghost_track)
 	ghost_track.channel = CHANNEL_CINEMATIC
 
-	for(var/i in GLOB.xeno_mob_list)
-		var/mob/M = i
+	for(var/mob/M as anything in GLOB.xeno_mob_list)
 		SEND_SOUND(M, xeno_track)
 
-	for(var/i in GLOB.human_mob_list)
-		var/mob/M = i
+	for(var/mob/M as anything in GLOB.human_mob_list)
 		SEND_SOUND(M, human_track)
 
-	for(var/i in GLOB.observer_list)
-		var/mob/M = i
+	for(var/mob/M as anything in GLOB.observer_list)
 		if(ishuman(M.mind.current))
 			SEND_SOUND(M, human_track)
 			continue
@@ -321,14 +316,12 @@
 		color_override = "red"
 	)
 
-
 /datum/game_mode/infestation/announce()
 	to_chat(world, span_round_header("The current map is - [SSmapping.configs[GROUND_MAP].map_name]!"))
 
 /datum/game_mode/infestation/attempt_to_join_as_larva(client/waiter)
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	return HS.add_to_larva_candidate_queue(waiter)
-
 
 /datum/game_mode/infestation/spawn_larva(mob/xeno_candidate, mob/living/carbon/xenomorph/mother)
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
@@ -356,12 +349,12 @@
 	var/sound/S = sound(pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg'), channel = CHANNEL_CINEMATIC)
 	SEND_SOUND(world, S)
 
-	for(var/x in GLOB.player_list)
-		var/mob/M = x
+	for(var/mob/M as anything in GLOB.player_list)
 		if(isobserver(M) || isnewplayer(M))
 			continue
-		if(M.z == z_level)
-			shake_camera(M, 110, 4)
+		if(M.z != z_level)
+			continue
+		shake_camera(M, 110, 4)
 
 	var/datum/cinematic/nuke/crash/C
 	var/nuketime = initial(C.runtime) + initial(C.cleanup_time)
@@ -380,11 +373,9 @@
 	else
 		planet_nuked = INFESTATION_NUKE_COMPLETED_OTHER
 
-	for(var/i in GLOB.alive_living_list)
-		var/mob/living/victim = i
+	for(var/mob/living/victim as anything in GLOB.alive_living_list)
 		var/turf/victim_turf = get_turf(victim) //Sneaky people on lockers.
 		if(QDELETED(victim_turf) || victim_turf.z != z_level)
 			continue
-		victim.adjust_fire_loss(victim.maxHealth * 4)
-		victim.death()
+		INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob, gib))
 		CHECK_TICK


### PR DESCRIPTION
## `Основные изменения`
Время ожидания после анимации взрыва ядерки уменьшено с 30 секунд до 15.
Исправил отображение взрыва ядерки на краше.
## `Ченджлог`
```
:cl:
qol: Время ожидания после анимации взрыва ядерки уменьшено с 30 секунд до 15.
fix: Исправил отображение взрыва ядерки на краше.
/:cl:
```
