### PR TITLE
Buff (10x24, Ar21, rebalans Felon and ammo)

### DIFF
--- a/code/modules/projectiles/ammo_datums/bullet/rifle.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/rifle.dm
@@ -5,7 +5,7 @@
 	accurate_range = 12
 	damage = 25
 	penetration = 5
-	additional_xeno_penetration = 10
+	additional_xeno_penetration = 20
 	matter_cost = 4
 
 /datum/ammo/bullet/rifle/ap

--- a/code/modules/projectiles/ammo_datums/bullet/rifle.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/rifle.dm
@@ -179,7 +179,7 @@
 /datum/ammo/bullet/rifle/type16
 	name = "crude rifle bullet"
 	hud_state = "rifle_crude"
-	damage = 30
+	damage = 36
 	penetration = 10
 	additional_xeno_penetration = 15
 	matter_cost = 5

--- a/code/modules/projectiles/ammo_datums/bullet/rifle.dm
+++ b/code/modules/projectiles/ammo_datums/bullet/rifle.dm
@@ -179,7 +179,7 @@
 /datum/ammo/bullet/rifle/type16
 	name = "crude rifle bullet"
 	hud_state = "rifle_crude"
-	damage = 36
+	damage = 33
 	penetration = 10
 	additional_xeno_penetration = 15
 	matter_cost = 5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -734,7 +734,6 @@
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/foldable/bipod,
-		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -829,7 +829,7 @@
 	burst_amount = 3
 	autoburst_delay = 0.10 SECONDS
 	damage_falloff_mult = 2.1
-	damage_mult = 0.87
+	damage_mult = 0.8
 	akimbo_additional_delay = 2
 	akimbo_scatter_mod = 24
 	akimbo_additional_delay = 20

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -761,7 +761,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 35, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 5, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/stock/mpi_km)
-	damage_falloff_mult = 0.5
+	damage_falloff_mult = 0.6
 	force = 20
 	burst_amount = 2
 	autoburst_delay = 0.1 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -765,7 +765,7 @@
 	force = 20
 	burst_amount = 2
 	autoburst_delay = 0.1 SECONDS
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.24 SECONDS
 	placed_overlay_iconstate = "ak47"
 
 /obj/item/weapon/gun/rifle/type16/m2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -829,6 +829,7 @@
 	burst_amount = 3
 	autoburst_delay = 0.10 SECONDS
 	damage_falloff_mult = 2.1
+	damage_mult = 0.87
 	akimbo_additional_delay = 2
 	akimbo_scatter_mod = 24
 	akimbo_additional_delay = 20

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1961,7 +1961,7 @@
 	aim_fire_delay = 0.15 SECONDS
 	aim_speed_modifier = 1.5
 
-	fire_delay = 0.22 SECONDS
+	fire_delay = 0.2 SECONDS
 	burst_amount = 1
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -761,7 +761,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 35, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 5, "stock_y" = 12)
 	starting_attachment_types = list(/obj/item/attachable/stock/mpi_km)
-	damage_falloff_mult = 0.6
+	damage_falloff_mult = 0.7
 	force = 20
 	burst_amount = 2
 	autoburst_delay = 0.1 SECONDS
@@ -1961,7 +1961,7 @@
 	aim_fire_delay = 0.15 SECONDS
 	aim_speed_modifier = 1.5
 
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.21 SECONDS
 	burst_amount = 1
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1960,13 +1960,14 @@
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 46, "muzzle_y" = 16,"rail_x" = 18, "rail_y" = 19, "under_x" = 34, "under_y" = 13, "stock_x" = 0, "stock_y" = 13)
 	aim_fire_delay = 0.15 SECONDS
-	aim_speed_modifier = 2.5
+	aim_speed_modifier = 1.5
 
 	fire_delay = 0.22 SECONDS
 	burst_amount = 1
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2
 	scatter = -2
+    movement_acc_penalty_mult = 4
 	wield_delay = 0.8 SECONDS
 	aim_slowdown = 0.5
 	damage_falloff_mult = 0.5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -820,7 +820,7 @@
 	starting_attachment_types = list(/obj/item/attachable/foldable/som_carbine)
 	force = 10
 	burst_amount = 1
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.22 SECONDS
 	accuracy_mult = 0.75
 	scatter = 12
 	recoil = 2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1966,7 +1966,7 @@
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2
 	scatter = -2
-    movement_acc_penalty_mult = 4
+	movement_acc_penalty_mult = 4
 	wield_delay = 0.8 SECONDS
 	aim_slowdown = 0.5
 	damage_falloff_mult = 0.5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -765,7 +765,7 @@
 	force = 20
 	burst_amount = 2
 	autoburst_delay = 0.1 SECONDS
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.25 SECONDS
 	placed_overlay_iconstate = "ak47"
 
 /obj/item/weapon/gun/rifle/type16/m2
@@ -794,7 +794,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/flashlight/under,
-		/obj/item/attachable/burstfire_assembly,
 		/obj/item/attachable/foldable/bipod,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/extended_barrel,
@@ -821,7 +820,7 @@
 	starting_attachment_types = list(/obj/item/attachable/foldable/som_carbine)
 	force = 10
 	burst_amount = 1
-	fire_delay = 0.20 SECONDS
+	fire_delay = 0.2 SECONDS
 	accuracy_mult = 0.75
 	scatter = 12
 	recoil = 2
@@ -829,7 +828,7 @@
 	movement_acc_penalty_mult = 4
 	burst_amount = 3
 	autoburst_delay = 0.10 SECONDS
-	damage_falloff_mult = 2.3
+	damage_falloff_mult = 2.1
 	akimbo_additional_delay = 2
 	akimbo_scatter_mod = 24
 	akimbo_additional_delay = 20

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -829,7 +829,7 @@
 	burst_amount = 3
 	autoburst_delay = 0.10 SECONDS
 	damage_falloff_mult = 2.1
-	damage_mult = 0.87
+	damage_mult = 0.91
 	akimbo_additional_delay = 2
 	akimbo_scatter_mod = 24
 	akimbo_additional_delay = 20

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1962,7 +1962,7 @@
 	aim_fire_delay = 0.15 SECONDS
 	aim_speed_modifier = 2.5
 
-	fire_delay = 0.25 SECONDS
+	fire_delay = 0.22 SECONDS
 	burst_amount = 1
 	burst_delay = 0.15 SECONDS
 	accuracy_mult = 1.2

--- a/html/changelogs/AutoChangeLog-pr-1153.yml
+++ b/html/changelogs/AutoChangeLog-pr-1153.yml
@@ -1,0 +1,4 @@
+author: "Helg2"
+delete-after: True
+changes:
+  - balance: "За сурвивора теперь нельзя зайти вне раундстарта."


### PR DESCRIPTION
## `Основные изменения`

СМОТРИТЕ В ЧЕНДЖЛОГ

## `Как это улучшит игру`

Данный баф уже давным давным давно был нужен учитывая новый баланс пп.

Баф 10X24 сделает пушки которые были из пп в -> стандартный автомат. По больше части калибру 10x24 после "Тартала" Стал отвратительным калибром который мало что мог против Т4 и Т3. А когда есть более хорошее альтернативы виде Грозы, Фелона, Бр64. Смысл брать пушки с калибром 10x24 стало всё меньше. Добила крышку гроба бафф ПП.
 
Баф Ар21 упростит использования данной пушки и хоть что-то предложить нормальное против Felon. 
У Ар21 очень мало причин его использовать что в времена Ашана что в Реборне это очень сомнительный ган.
Плюсы мало. Да магазин на 50, да хорошая точность и... всё! Больше нечего нету, ни аим, ни режимов огня, даже хороший скорострельности нету. А если даже реализовать магазин на 50 то это адская боль от которого хочется дропнуть пушку.

Ребаланс Фелона в сторону логики Кс.
Есть М4 и АК.
АК менее скорострельная, но мощная.
М4 Более скорострельная, но меньше дамага.

## `Ченджлог`
```
:cl:
balance-qol: Увеличил скорострельность с 0.25 -> 0.21 это упростит всей реализацию магазина Ар21
balance: Ар21 баланс Уменьшил замедление в аим. Уменьшил замедление в двух руках.
balance: Изменил баланс 10X24 xeno_penetration  10 -> 20
balance: Убрал у Felon и Зари брюс асемблер, изменил урон, и изменил скорострельность.
/:cl:
```
