### PR TITLE
Remove toxin spit at the praetorian

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -31,7 +31,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
-	spit_types = list(/datum/ammo/xeno/acid/heavy/passthrough, /datum/ammo/xeno/tox_loss/heavy)
+	spit_types = list(/datum/ammo/xeno/acid/heavy/passthrough)
 	acid_spray_duration = 6 SECONDS
 	acid_spray_damage = 8
 	acid_spray_duration = 10 SECONDS


### PR DESCRIPTION
## `Основные изменения`
Убран нейроплевок у претора.

## `Как это улучшит игру`
Бесполезная абилка после вывода нейротоксина, которую юзают только новайсы.
Сама абилка будет переработана под стрейн сента.

## `Ченджлог`
```
:cl:
del: Убрал возможность выбрать нейроплевок у претора
/:cl:
```